### PR TITLE
Prevent Python interpreter from crashing when the blossom algorithm fails

### DIFF
--- a/src/pymatching/bindings.cpp
+++ b/src/pymatching/bindings.cpp
@@ -68,6 +68,8 @@ PYBIND11_MODULE(_cpp_mwpm, m) {
      .def_readwrite("correction", &MatchingResult::correction)
      .def_readwrite("weight", &MatchingResult::weight);
 
+     py::register_exception<BlossomFailureException>(m, "BlossomFailureException", PyExc_RuntimeError);
+
      m.def("decode_match_neighbourhood", &LemonDecodeMatchNeighbourhood,
            "sg"_a, "defects"_a, "num_neighbours"_a=20,
            "return_weight"_a=false);

--- a/src/pymatching/lemon_mwpm.cpp
+++ b/src/pymatching/lemon_mwpm.cpp
@@ -26,7 +26,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <boost/graph/adjacency_list.hpp>
-#include <lemon/lgf_writer.h>
 
 typedef lemon::ListGraph UGraph;
 typedef UGraph::EdgeMap<double> LengthMap;
@@ -164,7 +163,7 @@ MatchingResult LemonDecodeMatchNeighbourhood(WeightedStabiliserGraph& sg, const 
     bool success = pm.run();
     if (!success){
         throw BlossomFailureException();
-        }
+    }
 
     int N = sg.GetNumQubits();
     auto correction = new std::vector<int>(N, 0);

--- a/src/pymatching/lemon_mwpm.cpp
+++ b/src/pymatching/lemon_mwpm.cpp
@@ -26,9 +26,18 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 #include <boost/graph/adjacency_list.hpp>
+#include <lemon/lgf_writer.h>
 
 typedef lemon::ListGraph UGraph;
 typedef UGraph::EdgeMap<double> LengthMap;
+typedef lemon::MaxWeightedPerfectMatching<UGraph,LengthMap> MWPM;
+
+
+const char * BlossomFailureException::what() const throw() {
+    return "The Lemon implementation of the blossom algorithm "
+            "(lemon::MaxWeightedPerfectMatching) "
+            "was unable to find a solution due to an error.";
+}
 
 
 class DefectGraph {
@@ -70,24 +79,17 @@ MatchingResult LemonDecode(IStabiliserGraph& sg, const py::array_t<int>& defects
             defect_graph.AddEdge(i, j, -1.0*sg.SpaceTimeDistance(d(i), d(j)));
         }
     };
-    typedef lemon::MaxWeightedPerfectMatching<UGraph,LengthMap> MWPM;
     MWPM pm(defect_graph.g, defect_graph.length);
-    pm.run();
+    bool success = pm.run();
+    if (!success){
+        throw BlossomFailureException();
+    }
 
     int N = sg.GetNumQubits();
     auto correction = new std::vector<int>(N, 0);
     std::set<int> qids;
     for (py::size_t i = 0; i<num_nodes; i++){
         int j = defect_graph.g.id(pm.mate(defect_graph.g.nodeFromId(i)));
-        if (i == j){
-            throw std::runtime_error(
-                "The blossom algorithm was unable to find a solution "
-                "to the MWPM problem. This is due to an issue in the LEMON "
-                "graph library, which occurs for some specific matching graphs. "
-                "See issue #11 for more "
-                "information (https://github.com/oscarhiggott/PyMatching/issues/11)."
-                );
-        }
         if (i<j){
             std::vector<int> path = sg.SpaceTimeShortestPath(d(i), d(j));
             for (std::vector<int>::size_type k=0; k<path.size()-1; k++){
@@ -158,9 +160,11 @@ MatchingResult LemonDecodeMatchNeighbourhood(WeightedStabiliserGraph& sg, const 
         throw std::runtime_error("Graph must have only one connected component");
     }
 
-    typedef lemon::MaxWeightedPerfectMatching<UGraph,LengthMap> MWPM;
     MWPM pm(defect_graph->g, defect_graph->length);
-    pm.run();
+    bool success = pm.run();
+    if (!success){
+        throw BlossomFailureException();
+        }
 
     int N = sg.GetNumQubits();
     auto correction = new std::vector<int>(N, 0);
@@ -179,17 +183,6 @@ MatchingResult LemonDecodeMatchNeighbourhood(WeightedStabiliserGraph& sg, const 
         remaining_defects.erase(remaining_defects.begin());
         j = defect_graph->g.id(pm.mate(defect_graph->g.nodeFromId(i)));
         remaining_defects.erase(j);
-        if (i == j){
-            throw std::runtime_error(
-                "The blossom algorithm was unable to find a solution "
-                "to the MWPM problem. This is due to an issue in the LEMON "
-                "graph library, which occurs for some specific matching graphs, "
-                "typically when num_neighbours<30. While this issue is being resolved, "
-                "a workaround is to set num_neighbours>30 when calling Matching.decode, "
-                "which may prevent this exception being raised. See issue #11 for more "
-                "information (https://github.com/oscarhiggott/PyMatching/issues/11)."
-                );
-        }
         path = sg.GetPath(d(i), d(j));
         for (std::vector<int>::size_type k=0; k<path.size()-1; k++){
             qids = sg.QubitIDs(path[k], path[k+1]);

--- a/src/pymatching/lemon_mwpm.h
+++ b/src/pymatching/lemon_mwpm.h
@@ -16,6 +16,13 @@
 #include "stabiliser_graph.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <exception>
+
+
+struct BlossomFailureException : public std::exception {
+    const char * what() const throw();
+};
+
 
 /**
  * @brief A struct containing the output of the minimum weight perfect matching decoder.

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -23,7 +23,8 @@ from pymatching._cpp_mwpm import (decode,
                             decode_match_neighbourhood,
                             WeightedStabiliserGraph,
                             BlossomFailureException)
-
+# alias to let unittest mock decode_match_neighbourhood
+_py_decode_match_neighbourhood = decode_match_neighbourhood
 
 
 def _find_boundary_nodes(G):
@@ -55,7 +56,7 @@ def _local_matching(stabiliser_graph, defects, num_neighbours, return_weight=Fal
     at nodes in `defects`. Each defect node can be matched to one of the `num_neighbours` 
     nearest defects. This function uses the Lemon library's MaxWeightedPerfectMatching 
     implementation of the blossom algorithm. If Lemon fails to find a solution, this function
-    retries at most `num_attempts` times, increasing `num_neighbours` by 10 between each attempt.
+    retries at most `num_attempts` times, increasing `num_neighbours` by 5 between each attempt.
 
     Parameters
     ----------
@@ -90,12 +91,12 @@ def _local_matching(stabiliser_graph, defects, num_neighbours, return_weight=Fal
     attempts_remaining = num_attempts
     while True:
         try:
-            return decode_match_neighbourhood(stabiliser_graph, defects, num_neighbours, return_weight)
+            return _py_decode_match_neighbourhood(stabiliser_graph, defects, num_neighbours, return_weight)
         except BlossomFailureException:
             if attempts_remaining <= 1 or num_neighbours >= len(defects):
                 raise
             else:
-                num_neighbours += 10
+                num_neighbours += 5
                 attempts_remaining -= 1
 
 


### PR DESCRIPTION
Adds `BlossomFailureException` which is thrown when `lemon::MaxWeightedPerfectMatching` fails to solve the matching problem, preventing a segmentation fault. If a `BlossomFailureException` is thrown when local matching is used, it is caught by `pymatching.matching._local_matching`, which increases `num_neighbours` and retries decoding. If multiple attempts of this fail, the `BlossomFailureException` is re-raised.

Fixes #11 