### PR TITLE
Fix win32 python310

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -37,7 +37,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp3*-*"
-          CIBW_SKIP: "*-win32 cp310-win_amd64"
+          CIBW_SKIP: "*-win32"
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Fix issue #24 by updating the pybind11 submodule and adding python 3.10 windows builds back into the CI