### PR TITLE
Added method Matching.decode_batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ with stim, in order to count the number of mistakes and estimate the logical err
 ```python
 num_errors = 0
 for i in range(syndrome.shape[0]):
-    predicted_observables = matching.decode(syndrome[i,:])
-    num_errors += not np.array_equal(actual_observables[i,:], predicted_observables)
+    predicted_observables = matching.decode(syndrome[i, :])
+    num_errors += not np.array_equal(actual_observables[i, :], predicted_observables)
 
 print(num_errors)  # prints 8
 ```

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -554,8 +554,8 @@ class Matching:
                "{} detector{}, " \
                "{} boundary node{}, " \
                "and {} edge{}>".format(
-            m, 's' if m != 1 else '', b, 's' if b != 1 else '',
-            e, 's' if e != 1 else '')
+                m, 's' if m != 1 else '', b, 's' if b != 1 else '',
+                e, 's' if e != 1 else '')
 
     def add_edge(
             self,

--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.cc
@@ -85,7 +85,9 @@ void process_timeline_until_completion(pm::Mwpm& mwpm, const std::vector<uint64_
         // Just add detection events if graph has no negative weights
         for (auto& detection : detection_events) {
             if (detection >= mwpm.flooder.graph.nodes.size())
-                throw std::invalid_argument("Detection event index too large");
+                throw std::invalid_argument("The detection event with index " + std::to_string(detection)
+                                            + " does not correspond to a node in the graph, which only has "
+                                            + std::to_string(mwpm.flooder.graph.nodes.size()) + " nodes.");
             if (detection + 1 > mwpm.flooder.graph.is_user_graph_boundary_node.size() ||
                 !mwpm.flooder.graph.is_user_graph_boundary_node[detection])
                 mwpm.create_detection_event(&mwpm.flooder.graph.nodes[detection]);

--- a/tests/matching/decode_test.py
+++ b/tests/matching/decode_test.py
@@ -220,6 +220,7 @@ def test_detection_event_too_large_raises_value_error():
     with pytest.raises(ValueError):
         m.decode_batch([[8]], bit_packed_shots=True)
 
+
 def test_deprecated_position_arguments_raise_deprecation_warning():
     m = Matching()
     m.add_edge(0, 1, fault_ids={0}, weight=4)

--- a/tests/matching/decode_test.py
+++ b/tests/matching/decode_test.py
@@ -19,6 +19,7 @@ import pytest
 import networkx as nx
 import os
 
+import pymatching
 from pymatching import Matching
 
 THIS_DIR = pathlib.Path(__file__).parent.resolve()
@@ -159,7 +160,7 @@ def test_surface_code_solution_weights():
             DATA_DIR,
             "surface_code_rotated_memory_x_13_0.01_1000_shots_no_buckets_predictions_pymatchingv0.7_exact.txt"),
             "r") as f:
-        expected_observables = [float(w) for w in f.readlines()]
+        expected_observables = [int(w) for w in f.readlines()]
     assert shots.shape == (1000, m.num_detectors + m.num_fault_ids)
     weights = []
     predicted_observables = []
@@ -171,6 +172,53 @@ def test_surface_code_solution_weights():
         assert weights[i] == pytest.approx(expected_weights[i], rel=1e-8)
     assert predicted_observables == expected_observables[0:len(predicted_observables)]
 
+    expected_observables_arr = np.zeros((shots.shape[0], 1), dtype=np.uint8)
+    expected_observables_arr[:, 0] = np.array(expected_observables)
+
+    sampler = dem.compile_sampler()
+    temp_shots, _, _ = sampler.sample(shots=10, bit_packed=True)
+    assert temp_shots.shape[1] == np.ceil(dem.num_detectors // 8)
+
+    batch_predictions = m.decode_batch(shots[:, 0:-m.num_fault_ids])
+    assert np.array_equal(batch_predictions, expected_observables_arr)
+
+    batch_predictions, batch_weights = m.decode_batch(shots[:, 0:-m.num_fault_ids], return_weights=True)
+    assert np.array_equal(batch_predictions, expected_observables_arr)
+    assert np.allclose(batch_weights, expected_weights, rtol=1e-8)
+
+    bitpacked_shots = np.packbits(shots[:, 0:dem.num_detectors], bitorder='little', axis=1)
+    batch_predictions_from_bitpacked, bitpacked_batch_weights = m.decode_batch(bitpacked_shots, return_weights=True,
+                                                                               bit_packed_shots=True)
+    assert np.array_equal(batch_predictions_from_bitpacked, expected_observables_arr)
+    assert np.allclose(bitpacked_batch_weights, expected_weights, rtol=1e-8)
+
+    bitpacked_batch_predictions_from_bitpacked, bitpacked_batch_weights = m.decode_batch(bitpacked_shots,
+                                                                                         return_weights=True,
+                                                                                         bit_packed_shots=True,
+                                                                                         bit_packed_predictions=True)
+    assert np.array_equal(bitpacked_batch_predictions_from_bitpacked, expected_observables_arr)
+    assert np.allclose(bitpacked_batch_weights, expected_weights, rtol=1e-8)
+
+
+def test_decode_batch_to_bitpacked_predictions():
+    m = pymatching.Matching()
+    m.add_edge(0, 1, fault_ids={0})
+    m.add_edge(1, 2, fault_ids={10})
+    m.add_edge(2, 3, fault_ids={3})
+    m.add_edge(3, 4, fault_ids={20})
+
+    predictions = m.decode_batch(np.array([[1, 0, 1, 0, 0], [0, 0, 1, 0, 1]], dtype=np.uint8),
+                                 bit_packed_predictions=True)
+    assert np.array_equal(predictions, np.array([[1, 4, 0], [8, 0, 16]], dtype=np.uint8))
+
+
+def test_detection_event_too_large_raises_value_error():
+    m = pymatching.Matching()
+    m.add_edge(0, 1)
+    with pytest.raises(ValueError):
+        m.decode([1, 0, 1])
+    with pytest.raises(ValueError):
+        m.decode_batch([[8]], bit_packed_shots=True)
 
 def test_deprecated_position_arguments_raise_deprecation_warning():
     m = Matching()

--- a/tests/matching/docstrings_test.py
+++ b/tests/matching/docstrings_test.py
@@ -15,9 +15,11 @@
 import pymatching
 
 import doctest
+import pytest
 
 
 def test_matching_docstrings():
+    pytest.importorskip("stim")
     doctest.testmod(pymatching.matching, raise_on_error=True)
 
 


### PR DESCRIPTION
Fixes #32. Adds `pymatching.Matching.decode_batch`, with options to load from bit-packed (or not) shots numpy arrays, and return bit-packed (or not) predictions numpy arrays. Faster than looping over `Matching.decode` in Python, especially for small problems sizes or low p. E.g. when decoding d=11, p=0.1% surface code circuits, looping over `Matching.decode` is 1us per round vs 0.37us per round using `Matching.decode_batch`. For d=5, p=0.01%, looping `Matching.decode` in python is 0.8us per round vs 0.02us per round with `Matching.decode_batch`.