### PR TITLE
Fixed typo in toric code documentation

### DIFF
--- a/docs/toric-code-example.ipynb
+++ b/docs/toric-code-example.ipynb
@@ -142,7 +142,7 @@
     "The actual logicals that were flipped are:\n",
     "\n",
     "```\n",
-    "actual_logicals_flipped = logicals@prediction % 2\n",
+    "actual_logicals_flipped = logicals@noise % 2\n",
     "```\n",
     "\n",
     "Our decoder was successful if `actual_logical_observables` equals `predicted_logical_observables`.\n",


### PR DESCRIPTION
actual_logical_flipped is determined by noise, not by the prediction. Fixed this one line in the documentation.