### PR TITLE
Remove unnecessary line from driver/io.h

### DIFF
--- a/src/pymatching/sparse_blossom/driver/io.h
+++ b/src/pymatching/sparse_blossom/driver/io.h
@@ -114,7 +114,6 @@ inline double IntermediateWeightedGraph::iter_discretized_edges(
     const EdgeCallable &edge_func,
     const BoundaryEdgeCallable &boundary_edge_func) {
     double max_weight = max_abs_weight();
-    pm::MatchingGraph matching_graph(nodes.size(), num_observables);
     pm::weight_int max_half_edge_weight = num_distinct_weights - 1;
     double normalising_constant = (double)max_half_edge_weight / max_weight;
     for (auto &node : nodes) {


### PR DESCRIPTION
Perhaps this `pm::MatchingGraph` construction was left in by accident from a previous implementation of `iter_discretized_edges`. It has no effect here so may as well remove it.