### PR TITLE
Make it easier to use pymatching as a C++ dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/DOCS_ENV
 docs/sphinx_docs/build
 data/DATA_ENV
 build
+build.ninja

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ docs/sphinx_docs/build
 data/DATA_ENV
 build
 build.ninja
+.ninja_deps
+.ninja_log

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,64 @@
+package(default_visibility = ["//visibility:public"])
+
+SOURCE_FILES_NO_MAIN = glob(
+    [
+        "src/**/*.cc",
+        "src/**/*.h",
+        "src/**/*.inl",
+    ],
+    exclude = glob([
+        "src/**/*.test.cc",
+        "src/**/*.test.h",
+        "src/**/*.perf.cc",
+        "src/**/*.perf.h",
+        "src/**/*.pybind.cc",
+        "src/**/*.pybind.h",
+        "src/**/main.cc",
+    ]),
+)
+
+TEST_FILES = glob(
+    [
+        "src/**/*.test.cc",
+        "src/**/*.test.h",
+    ],
+)
+
+cc_binary(
+    name = "pymatching",
+    srcs = SOURCE_FILES_NO_MAIN + glob(["src/**/main.cc"]),
+    copts = [
+        "-std=c++20",
+        "-O3",
+        "-DNDEBUG",
+    ],
+    includes = ["src/"],
+    deps = ["@stim//:stim_lib"],
+)
+
+cc_library(
+    name = "libpymatching",
+    srcs = SOURCE_FILES_NO_MAIN,
+    copts = [
+        "-std=c++20",
+        "-O3",
+        "-DNDEBUG",
+    ],
+    includes = ["src/"],
+    deps = ["@stim//:stim_lib"],
+)
+
+cc_test(
+    name = "pymatching_test",
+    srcs = SOURCE_FILES_NO_MAIN + TEST_FILES,
+    copts = [
+        "-std=c++20",
+    ],
+    data = glob(["testdata/**"]),
+    includes = ["src/"],
+    deps = [
+        "@gtest",
+        "@gtest//:gtest_main",
+        "@stim//:stim_lib",
+    ],
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ target_link_libraries(libpymatching libstim)
 include(GoogleTest)
 gtest_discover_tests(pymatching_tests)
 
-IF(EXISTS pybind11/CMakeLists.txt)
+IF(EXISTS ${CMAKE_CURRENT_LIST_DIR}/pybind11/CMakeLists.txt)
     add_subdirectory(pybind11)
     pybind11_add_module(_cpp_pymatching ${PYTHON_API_FILES} ${SOURCE_FILES_NO_MAIN})
     target_link_libraries(_cpp_pymatching PRIVATE libstim)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ FetchContent_MakeAvailable(googletest)
 
 FetchContent_Declare(stim
         GIT_REPOSITORY https://github.com/quantumlib/stim.git
-        GIT_TAG 7bef1fc275a34ecff912e90be8c9e4b1d3f120db)
+        GIT_TAG c135a6129963031b5c05f974e9c5e8def83f8316)
 FetchContent_MakeAvailable(stim)
 if (NOT (MSVC))
     target_compile_options(libstim PRIVATE -fno-strict-aliasing -fPIC ${ARCH_OPT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ FetchContent_MakeAvailable(googletest)
 
 FetchContent_Declare(stim
         GIT_REPOSITORY https://github.com/quantumlib/stim.git
-        GIT_TAG 15f9dd72210d0a7fdc8602d3d03ebb7ce9271d9d)
+        GIT_TAG 7bef1fc275a34ecff912e90be8c9e4b1d3f120db)
 FetchContent_MakeAvailable(stim)
 if (NOT (MSVC))
     target_compile_options(libstim PRIVATE -fno-strict-aliasing -fPIC ${ARCH_OPT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,12 +121,27 @@ if (NOT (MSVC))
 endif ()
 target_link_libraries(pymatching_perf libstim)
 
+add_library(libpymatching ${SOURCE_FILES_NO_MAIN})
+set_target_properties(libpymatching PROPERTIES PREFIX "")
+target_include_directories(libpymatching PUBLIC src)
+target_compile_options(libpymatching PRIVATE ${ARCH_OPT})
+if(NOT(MSVC))
+    target_link_options(libpymatching PRIVATE -pthread -O3)
+endif()
+target_link_libraries(libpymatching libstim)
+
 include(GoogleTest)
 gtest_discover_tests(pymatching_tests)
-add_subdirectory(pybind11)
-pybind11_add_module(_cpp_pymatching ${PYTHON_API_FILES} ${SOURCE_FILES_NO_MAIN})
-target_link_libraries(_cpp_pymatching PRIVATE libstim)
-target_compile_options(_cpp_pymatching PRIVATE ${ARCH_OPT})
+
+IF(EXISTS pybind11/CMakeLists.txt)
+    add_subdirectory(pybind11)
+    pybind11_add_module(_cpp_pymatching ${PYTHON_API_FILES} ${SOURCE_FILES_NO_MAIN})
+    target_link_libraries(_cpp_pymatching PRIVATE libstim)
+    target_compile_options(_cpp_pymatching PRIVATE ${ARCH_OPT})
+else()
+    message("WARNING: Skipped the pybind11 module _cpp_pymatching because the `pybind11` git submodule isn't present. To fix, run `git submodule update --init --recursive`")
+endif()
+
 # EXAMPLE_VERSION_INFO is defined by setup.py and passed into the C++ code as a
 # define (VERSION_INFO) here.
 #target_compile_definitions(_cpp_pymatching

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,43 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "stim",
+    commit = "c135a6129963031b5c05f974e9c5e8def83f8316",
+    remote = "https://github.com/quantumlib/stim.git",
+)
+
+http_archive(
+    name = "gtest",
+    sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
+    strip_prefix = "googletest-release-1.11.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip"],
+)
+
+http_archive(
+    name = "pybind11",
+    build_file = "@pybind11_bazel//:pybind11.BUILD",
+    sha256 = "832e2f309c57da9c1e6d4542dedd34b24e4192ecb4d62f6f4866a737454c9970",
+    strip_prefix = "pybind11-2.10.4",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.10.4.tar.gz"],
+)
+
+http_archive(
+    name = "pybind11_bazel",
+    sha256 = "b72c5b44135b90d1ffaba51e08240be0b91707ac60bea08bb4d84b47316211bb",
+    strip_prefix = "pybind11_bazel-b162c7c88a253e3f6b673df0c621aca27596ce6b",
+    urls = ["https://github.com/pybind/pybind11_bazel/archive/b162c7c88a253e3f6b673df0c621aca27596ce6b.zip"],
+)
+
+http_archive(
+    name = "rules_python",
+    sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
+    strip_prefix = "rules_python-0.23.1",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
+load("@pybind11_bazel//:python_configure.bzl", "python_configure")
+python_configure(name = "local_config_python")

--- a/setup.py
+++ b/setup.py
@@ -153,5 +153,7 @@ setup(
         'console_scripts': ['pymatching=pymatching._cli_argv:cli_argv'],
     },
     python_requires=">=3.6",
-    install_requires=['scipy', 'numpy', 'networkx', 'retworkx>=0.11.0', 'matplotlib']
+    install_requires=['scipy', 'numpy', 'networkx', 'retworkx>=0.11.0', 'matplotlib'],
+    # Needed on Windows to avoid the default `build` colliding with Bazel's `BUILD`.
+    options={'build': {'build_base': 'python_build_stim'}},
 )

--- a/src/pymatching/sparse_blossom/diagram/animation_main.cc
+++ b/src/pymatching/sparse_blossom/diagram/animation_main.cc
@@ -60,7 +60,7 @@ int pm::main_animation(int argc, const char **argv) {
     }
 
     auto dem = stim::DetectorErrorModel::from_file(dem_file);
-    auto dets_reader = stim::MeasureRecordReader::make(
+    auto dets_reader = stim::MeasureRecordReader<stim::MAX_BITWORD_WIDTH>::make(
         dets_file, dets_in_format.id, 0, dem.count_detectors(), dem.count_observables() * dets_includes_obs);
     stim::SparseShot shot;
     if (!dets_reader->start_and_read_entire_record(shot)) {

--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
@@ -222,7 +222,6 @@ std::vector<uint64_t> get_syndrome_from_edges(const std::vector<int64_t>& edges)
 
 uint64_t get_observables_from_edges(const std::vector<int64_t>& edges, pm::Mwpm& mwpm) {
     uint64_t obs_mask = 0;
-    pm::total_weight_int tot_weight = 0;
     for (size_t i = 0; i < edges.size() / 2; i++) {
         int64_t u = edges[2 * i];
         int64_t v = edges[2 * i + 1];

--- a/src/pymatching/sparse_blossom/driver/namespaced_main.cc
+++ b/src/pymatching/sparse_blossom/driver/namespaced_main.cc
@@ -23,7 +23,6 @@
 #include "pymatching/sparse_blossom/driver/io.h"
 #include "pymatching/sparse_blossom/driver/mwpm_decoding.h"
 #include "stim.h"
-#include "stim/simulators/detection_simulator.h"
 
 int main_predict(int argc, const char **argv) {
     stim::check_for_unknown_arguments(
@@ -54,7 +53,7 @@ int main_predict(int argc, const char **argv) {
 
     size_t num_obs = dem.count_observables();
     auto reader =
-        stim::MeasureRecordReader::make(shots_in, shots_in_format.id, 0, dem.count_detectors(), append_obs * num_obs);
+        stim::MeasureRecordReader<stim::MAX_BITWORD_WIDTH>::make(shots_in, shots_in_format.id, 0, dem.count_detectors(), append_obs * num_obs);
     auto writer = stim::MeasureRecordWriter::make(predictions_out, predictions_out_format.id);
     writer->begin_result_type('L');
 
@@ -118,12 +117,12 @@ int main_count_mistakes(int argc, const char **argv) {
     fclose(dem_file);
 
     size_t num_obs = dem.count_observables();
-    std::unique_ptr<stim::MeasureRecordReader> obs_reader;
+    std::unique_ptr<stim::MeasureRecordReader<stim::MAX_BITWORD_WIDTH>> obs_reader;
     if (obs_in != stdin) {
-        obs_reader = stim::MeasureRecordReader::make(obs_in, obs_in_format.id, 0, 0, num_obs);
+        obs_reader = stim::MeasureRecordReader<stim::MAX_BITWORD_WIDTH>::make(obs_in, obs_in_format.id, 0, 0, num_obs);
     }
     auto reader =
-        stim::MeasureRecordReader::make(shots_in, shots_in_format.id, 0, dem.count_detectors(), append_obs * num_obs);
+        stim::MeasureRecordReader<stim::MAX_BITWORD_WIDTH>::make(shots_in, shots_in_format.id, 0, dem.count_detectors(), append_obs * num_obs);
 
     pm::weight_int num_buckets = pm::NUM_DISTINCT_WEIGHTS;
     auto mwpm = pm::detector_error_model_to_mwpm(dem, num_buckets);
@@ -142,7 +141,7 @@ int main_count_mistakes(int argc, const char **argv) {
             }
         }
         auto res = pm::decode_detection_events_for_up_to_64_observables(mwpm, sparse_shot.hits);
-        if (obs_shot.obs_mask != res.obs_mask) {
+        if (obs_shot.obs_mask_as_u64() != res.obs_mask) {
             num_mistakes++;
         }
         sparse_shot.clear();

--- a/src/pymatching/sparse_blossom/flooder/detector_node.h
+++ b/src/pymatching/sparse_blossom/flooder/detector_node.h
@@ -34,12 +34,12 @@ namespace pm {
 class DetectorNode {
    public:
     DetectorNode()
-        : observables_crossed_from_source(0),
-          reached_from_source(nullptr),
-          radius_of_arrival(0),
-          region_that_arrived(nullptr),
+        : region_that_arrived(nullptr),
           region_that_arrived_top(nullptr),
-          wrapped_radius_cached(0) {
+          wrapped_radius_cached(0),
+          reached_from_source(nullptr),
+          observables_crossed_from_source(0),
+          radius_of_arrival(0) {
     }
 
     /// == Ephemeral fields used to track algorithmic state during matching. ==

--- a/src/pymatching/sparse_blossom/flooder/graph.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph.cc
@@ -104,8 +104,8 @@ MatchingGraph::MatchingGraph(MatchingGraph&& graph) noexcept
     : nodes(std::move(graph.nodes)),
       negative_weight_detection_events_set(std::move(graph.negative_weight_detection_events_set)),
       negative_weight_observables_set(std::move(graph.negative_weight_observables_set)),
-      is_user_graph_boundary_node(std::move(graph.is_user_graph_boundary_node)),
       negative_weight_sum(graph.negative_weight_sum),
+      is_user_graph_boundary_node(std::move(graph.is_user_graph_boundary_node)),
       num_nodes(graph.num_nodes),
       num_observables(graph.num_observables),
       normalising_constant(graph.normalising_constant) {

--- a/src/pymatching/sparse_blossom/search/search_flooder.test.cc
+++ b/src/pymatching/sparse_blossom/search/search_flooder.test.cc
@@ -99,8 +99,9 @@ TEST(SearchFlooder, RepCodeSourceToDestPath) {
         std::vector<size_t> node_indices;
         for (size_t i = 0; i < edges.size(); i++) {
             node_indices.push_back(edges[i].detector_node - &flooder.graph.nodes[0]);
-            if (i + 1 < edges.size())
+            if (i + 1 < edges.size()) {
                 ASSERT_EQ(edges[i].detector_node->neighbors[edges[i].neighbor_index], edges[i + 1].detector_node);
+            }
         }
         std::vector<size_t> expected_node_indices;
         for (size_t i = i_start; i < i_end; i++)


### PR DESCRIPTION
- Add a `libpymatching` target to the CMakeLists.txt file
- Add support for building with bazel
    - Add a `WORKSPACE` file
    - Add a `BUILD` file
    - Try it with `bazel build :all`
- Add an `IF(EXISTS ${CMAKE_CURRENT_LIST_DIR}/pybind11/CMakeLists.txt)` around the pybind11 cmake target
    - Also included a warning message that explains how to fix the issue
    - This avoids some issues where cmake fetching a project won't recursively fetch the submodules, preventing everything from working instead of just the pybind11 target
    - Also it avoids some potential getting-started issues, or at least defers them, with getting the code to build
- Fix some constructor order warnings in `DetectorNode` and `MatchingGraph`
- Fix some implicit downcast warnings
- Bump the stim commit tag to the latest one on main, and fix the resulting breakages
    - Most fixes were adding new bitword size template parameters and switching from `SparseShot.obs_mask` to `SparseShot.obs_mask_as_u64()`.

**Linking from CMake**

*Note the commit ID I'm using is the latest commit of this PR, not one on main.*

Here is now a way to use pymatching as a cmake dependency. In the CMakeLists.txt file fetch it using `FetchContent`:

```
FetchContent_Declare(pymatching
        GIT_REPOSITORY https://github.com/oscarhiggott/pymatching.git
        GIT_TAG 48098cf8d6d77fb4c2caf0ab319b31bde4d37d22 )
FetchContent_GetProperties(pymatching)
if(NOT pymatching_POPULATED)
  FetchContent_Populate(pymatching)
  add_subdirectory(${pymatching_SOURCE_DIR})
endif()
```

You can then link to it:

```
[...]
target_link_libraries(YOURLIBRARY libpymatching)
[...]
```

**Linking from Bazel**

*Note the commit ID I'm using is the latest commit of this PR, not one on main.*

In `WORKSPACE`:

```
load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
git_repository(
    name = "pymatching",
    commit = "48098cf8d6d77fb4c2caf0ab319b31bde4d37d22",
    remote = "https://github.com/oscarhiggott/pymatching.git",
)
```

In `BUILD`:

```
cc_binary(
    name = "your_project",
    ...
    deps = [
        "@pymatching//:libpymatching",
    ],
)
```

Fixes https://github.com/oscarhiggott/PyMatching/issues/76