### PR TITLE
Fix build failing when using gcc 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ build
 build.ninja
 .ninja_deps
 .ninja_log
+.clwb

--- a/src/pymatching/sparse_blossom/ints.h
+++ b/src/pymatching/sparse_blossom/ints.h
@@ -16,6 +16,7 @@
 #define PYMATCHING_INTS_H
 
 #include <cstddef>
+#include <cstdint>
 
 #include "pymatching/sparse_blossom/tracker/cyclic.h"
 


### PR DESCRIPTION
- Have to include `<cstdint>` to get types like uint64_t