### PR TITLE
Retworkx to rustworkx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         sudo apt update
         sudo apt install gcc-10 g++-10
 
-    - uses: pypa/cibuildwheel@v2.16.2
+    - uses: pypa/cibuildwheel@v2.16.4
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,32 +41,36 @@ jobs:
       matrix:
         os_dist: [
           # macosx x86_64
-          {os: macos-latest, dist: cp36-macosx_x86_64},
+          # {os: macos-latest, dist: cp36-macosx_x86_64},
           {os: macos-latest, dist: cp37-macosx_x86_64},
           {os: macos-latest, dist: cp38-macosx_x86_64},
           {os: macos-latest, dist: cp39-macosx_x86_64},
           {os: macos-latest, dist: cp310-macosx_x86_64},
           {os: macos-latest, dist: cp311-macosx_x86_64},
+          {os: macos-latest, dist: cp312-macosx_x86_64},
           # macosx arm64
           {os: macos-latest, dist: cp38-macosx_arm64},
           {os: macos-latest, dist: cp39-macosx_arm64},
           {os: macos-latest, dist: cp310-macosx_arm64},
           {os: macos-latest, dist: cp311-macosx_arm64},
+          {os: macos-latest, dist: cp312-macosx_arm64},
           # macosx universal2
           {os: macos-latest, dist: cp38-macosx_universal2},
           {os: macos-latest, dist: cp39-macosx_universal2},
           {os: macos-latest, dist: cp310-macosx_universal2},
           {os: macos-latest, dist: cp311-macosx_universal2},
+          {os: macos-latest, dist: cp312-macosx_universal2},
 
           # windows amd64
-          {os: windows-latest, dist: cp36-win_amd64},
+          # {os: windows-latest, dist: cp36-win_amd64},
           {os: windows-latest, dist: cp37-win_amd64},
           {os: windows-latest, dist: cp38-win_amd64},
           {os: windows-latest, dist: cp39-win_amd64},
           {os: windows-latest, dist: cp310-win_amd64},
           {os: windows-latest, dist: cp311-win_amd64},
+          {os: windows-latest, dist: cp312-win_amd64},
           # windows win32
-          {os: windows-latest, dist: cp36-win32},
+          # {os: windows-latest, dist: cp36-win32},
           {os: windows-latest, dist: cp37-win32},
           # scipy install fails
 #          {os: windows-latest, dist: cp38-win32},
@@ -79,14 +83,15 @@ jobs:
 #          {os: windows-latest, dist: cp311-win_arm64},
 
           # ubuntu x86_64
-          {os: ubuntu-latest, dist: cp36-manylinux_x86_64},
+          # {os: ubuntu-latest, dist: cp36-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp37-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp38-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp39-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp310-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp311-manylinux_x86_64},
+          {os: ubuntu-latest, dist: cp312-manylinux_x86_64},
           # ubuntu i686
-          {os: ubuntu-latest, dist: cp36-manylinux_i686},
+          # {os: ubuntu-latest, dist: cp36-manylinux_i686},
           {os: ubuntu-latest, dist: cp37-manylinux_i686},
           # scipy built distribution not available and build fails on manylinux_i686 for python 3.8 up
 #          {os: ubuntu-latest, dist: cp38-manylinux_i686},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         sudo apt update
         sudo apt install gcc-10 g++-10
 
-    - uses: pypa/cibuildwheel@v2.16.4
+    - uses: pypa/cibuildwheel@v2.16.2
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         sudo apt update
         sudo apt install gcc-10 g++-10
 
-    - uses: pypa/cibuildwheel@v2.11.1
+    - uses: pypa/cibuildwheel@v2.16.4
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cov.xml
 .coverage
 *.ipynb_checkpoints
 .idea
@@ -31,3 +32,4 @@ build.ninja
 .ninja_deps
 .ninja_log
 .clwb
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Testing/
 _deps/
 *.cmake
 ENV
+env
 circuits
 notes
 dist

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install pymatching --upgrade
 ## Usage
 
 PyMatching can load matching graphs from a check matrix, a `stim.DetectorErrorModel`, a `networkx.Graph`, a 
-`retworkx.PyGraph` or by adding edges individually with `pymatching.Matching.add_edge` and 
+`rustworkx.PyGraph` or by adding edges individually with `pymatching.Matching.add_edge` and 
 `pymatching.Matching.add_boundary_edge`.
 
 ### Decoding Stim circuits
@@ -287,7 +287,7 @@ Instead of using a check matrix, the Matching object can also be constructed usi
 the [`Matching.add_edge`](https://pymatching.readthedocs.io/en/stable/api.html#pymatching.matching.Matching.add_edge)
 and 
 [`Matching.add_boundary_edge`](https://pymatching.readthedocs.io/en/stable/api.html#pymatching.matching.Matching.add_boundary_edge) 
-methods, or by loading from a NetworkX or retworkx graph. 
+methods, or by loading from a NetworkX or rustworkx graph. 
 
 For more details on how to use PyMatching,
 see [the documentation](https://pymatching.readthedocs.io).

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ setup(
     entry_points={
         'console_scripts': ['pymatching=pymatching._cli_argv:cli_argv'],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=['scipy', 'numpy', 'networkx', 'rustworkx', 'matplotlib'],
     # Needed on Windows to avoid the default `build` colliding with Bazel's `BUILD`.
     options={'build': {'build_base': 'python_build_stim'}},

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
         'console_scripts': ['pymatching=pymatching._cli_argv:cli_argv'],
     },
     python_requires=">=3.6",
-    install_requires=['scipy', 'numpy', 'networkx', 'retworkx>=0.11.0', 'matplotlib'],
+    install_requires=['scipy', 'numpy', 'networkx', 'rustworkx', 'matplotlib'],
     # Needed on Windows to avoid the default `build` colliding with Bazel's `BUILD`.
     options={'build': {'build_base': 'python_build_stim'}},
 )

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -1476,8 +1476,8 @@ class Matching:
 
     def load_from_retworkx(self, graph: rx.PyGraph, *, min_num_fault_ids: int = None) -> None:
         r"""
-        Load a matching graph from a retworkX graph. This method is deprecated since the retworkx package has been 
-        renamed to rustworkx. Please use `pymatching.Matching.load_from_rustworkx` instead.
+        Load a matching graph from a retworkX graph. This method is deprecated since the retworkx package has been
+         renamed to rustworkx. Please use `pymatching.Matching.load_from_rustworkx` instead.
         """
         warnings.warn("`pymatching.Matching.load_from_retworkx` is now deprecated since the `retworkx` library has been "
                       "renamed to `rustworkx`. Please use `pymatching.Matching.load_from_rustworkx` instead.", DeprecationWarning, stacklevel=2)
@@ -1586,11 +1586,12 @@ class Matching:
         if has_virtual_boundary:
             graph.nodes[num_nodes]['is_boundary'] = True
         return graph
-    
+
     def to_retworkx(self) -> rx.PyGraph:
         """Deprecated, use `pymatching.Matching.to_rustworkx` instead (since the `retworkx` package has been renamed to `rustworkx`).
-        This method just calls `pymatching.Matching.to_rustworkx` and returns a `rustworkx.PyGraph`, which is now just the preferred name for `retworkx.PyGraph`.
-        Note that in the future, only the `rustworkx` package name will be supported, see: https://pypi.org/project/retworkx/.
+        This method just calls `pymatching.Matching.to_rustworkx` and returns a `rustworkx.PyGraph`, which is now just the preferred name for
+         `retworkx.PyGraph`. Note that in the future, only the `rustworkx` package name will be supported, 
+         see: https://pypi.org/project/retworkx/.
         """
         warnings.warn("`pymatching.Matching.to_retworkx` is now deprecated since the `retworkx` library has been "
                       "renamed to `rustworkx`. Please use `pymatching.Matching.to_rustworkx` instead.", DeprecationWarning, stacklevel=2)

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -1590,7 +1590,7 @@ class Matching:
     def to_retworkx(self) -> rx.PyGraph:
         """Deprecated, use `pymatching.Matching.to_rustworkx` instead (since the `retworkx` package has been renamed to `rustworkx`).
         This method just calls `pymatching.Matching.to_rustworkx` and returns a `rustworkx.PyGraph`, which is now just the preferred name for
-         `retworkx.PyGraph`. Note that in the future, only the `rustworkx` package name will be supported, 
+         `retworkx.PyGraph`. Note that in the future, only the `rustworkx` package name will be supported,
          see: https://pypi.org/project/retworkx/.
         """
         warnings.warn("`pymatching.Matching.to_retworkx` is now deprecated since the `retworkx` library has been "

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -1477,7 +1477,7 @@ class Matching:
     def load_from_retworkx(self, graph: rx.PyGraph, *, min_num_fault_ids: int = None) -> None:
         r"""
         Load a matching graph from a retworkX graph. This method is deprecated since the retworkx package has been
-         renamed to rustworkx. Please use `pymatching.Matching.load_from_rustworkx` instead.
+        renamed to rustworkx. Please use ``pymatching.Matching.load_from_rustworkx`` instead.
         """
         warnings.warn("`pymatching.Matching.load_from_retworkx` is now deprecated since the `retworkx` library has been "
                       "renamed to `rustworkx`. Please use `pymatching.Matching.load_from_rustworkx` instead.", DeprecationWarning, stacklevel=2)
@@ -1588,9 +1588,9 @@ class Matching:
         return graph
 
     def to_retworkx(self) -> rx.PyGraph:
-        """Deprecated, use `pymatching.Matching.to_rustworkx` instead (since the `retworkx` package has been renamed to `rustworkx`).
-        This method just calls `pymatching.Matching.to_rustworkx` and returns a `rustworkx.PyGraph`, which is now just the preferred name for
-         `retworkx.PyGraph`. Note that in the future, only the `rustworkx` package name will be supported,
+        """Deprecated, use ``pymatching.Matching.to_rustworkx`` instead (since the `retworkx` package has been renamed to `rustworkx`).
+        This method just calls ``pymatching.Matching.to_rustworkx`` and returns a ``rustworkx.PyGraph``, which is now just the preferred name for
+         ``retworkx.PyGraph``. Note that in the future, only the `rustworkx` package name will be supported,
          see: https://pypi.org/project/retworkx/.
         """
         warnings.warn("`pymatching.Matching.to_retworkx` is now deprecated since the `retworkx` library has been "

--- a/tests/matching/load_from_rustworkx_test.py
+++ b/tests/matching/load_from_rustworkx_test.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 import pytest
 
 from pymatching import Matching
 from pymatching._cpp_pymatching import MatchingGraph
 
 
-def test_boundary_from_retworkx():
+def test_boundary_from_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(5)])
     g.add_edge(4, 0, dict(fault_ids=0))
@@ -37,7 +37,7 @@ def test_boundary_from_retworkx():
     assert np.array_equal(m.decode(np.array([0, 0, 1, 0])), np.array([0, 0, 0, 1, 1]))
 
 
-def test_boundaries_from_retworkx():
+def test_boundaries_from_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(6)])
     g.add_edge(0, 1, dict(fault_ids=0))
@@ -56,7 +56,7 @@ def test_boundaries_from_retworkx():
     assert np.array_equal(m.decode(np.array([0, 0, 0, 1, 0])), np.array([0, 0, 0, 1, 1]))
 
 
-def test_unweighted_stabiliser_graph_from_retworkx():
+def test_unweighted_stabiliser_graph_from_rustworkx():
     w = rx.PyGraph()
     w.add_nodes_from([{} for _ in range(6)])
     w.add_edge(0, 1, dict(fault_ids=0, weight=7.0))
@@ -89,7 +89,7 @@ def test_unweighted_stabiliser_graph_from_retworkx():
     )
 
 
-def test_mwpm_from_retworkx():
+def test_mwpm_from_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(3)])
     g.add_edge(0, 1, dict(fault_ids=0))
@@ -121,7 +121,7 @@ def test_mwpm_from_retworkx():
     assert (m.num_fault_ids == 0)
 
 
-def test_matching_edges_from_retworkx():
+def test_matching_edges_from_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(4)])
     g.add_edge(0, 1, dict(fault_ids=0, weight=1.1, error_probability=0.1))
@@ -142,7 +142,7 @@ def test_matching_edges_from_retworkx():
     assert es == expected_edges
 
 
-def test_qubit_id_accepted_via_retworkx():
+def test_qubit_id_accepted_via_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(4)])
     g.add_edge(0, 1, dict(qubit_id=0, weight=1.1, error_probability=0.1))
@@ -162,29 +162,29 @@ def test_qubit_id_accepted_via_retworkx():
     assert es == expected_edges
 
 
-def test_load_from_retworkx_raises_value_error_if_qubit_id_and_fault_ids_both_supplied():
+def test_load_from_rustworkx_raises_value_error_if_qubit_id_and_fault_ids_both_supplied():
     with pytest.raises(ValueError):
         g = rx.PyGraph()
         g.add_nodes_from([{} for _ in range(3)])
         g.add_edge(0, 1, dict(qubit_id=0, fault_ids=0))
         g.add_edge(1, 2, dict(qubit_id=1, fault_ids=1))
         m = Matching()
-        m.load_from_retworkx(g)
+        m.load_from_rustworkx(g)
 
 
-def test_load_from_retworkx_type_errors_raised():
+def test_load_from_rustworkx_type_errors_raised():
     with pytest.raises(TypeError):
         m = Matching()
-        m.load_from_retworkx("A")
+        m.load_from_rustworkx("A")
     with pytest.raises(TypeError):
         g = rx.PyGraph()
         g.add_nodes_from([{} for _ in range(2)])
         g.add_edge(0, 1, dict(fault_ids={0, "a"}))
         m = Matching()
-        m.load_from_retworkx(g)
+        m.load_from_rustworkx(g)
     with pytest.raises(TypeError):
         g = rx.PyGraph()
         g.add_nodes_from([{} for _ in range(2)])
         g.add_edge(0, 1, dict(fault_ids=[[0], [2]]))
         m = Matching()
-        m.load_from_retworkx(g)
+        m.load_from_rustworkx(g)

--- a/tests/matching/output_graph_test.py
+++ b/tests/matching/output_graph_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import networkx as nx
-import retworkx as rx
+import rustworkx as rx
 
 from pymatching import Matching
 
@@ -59,7 +59,7 @@ def test_matching_to_networkx():
     assert list(g.nodes(data=True)) == [(0, {"is_boundary": False}), (1, {"is_boundary": False})]
 
 
-def test_matching_to_retworkx():
+def test_matching_to_rustworkx():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(4)])
     g.add_edge(0, 1, dict(fault_ids={0}, weight=1.1, error_probability=0.1))
@@ -76,7 +76,7 @@ def test_matching_to_retworkx():
     g[1]['is_boundary'] = False
     g[2]['is_boundary'] = False
 
-    g2 = m.to_retworkx()
+    g2 = m.to_rustworkx()
 
     assert g.node_indices() == g2.node_indices()
     gedges = [({s, t}, d) for (s, t, d) in g.weighted_edge_list()]
@@ -87,7 +87,7 @@ def test_matching_to_retworkx():
     m.add_boundary_edge(0, weight=2)
     m.add_edge(0, 1, weight=3)
     m.add_edge(1, 2, weight=4)
-    g = m.to_retworkx()
+    g = m.to_rustworkx()
     es = list(g.weighted_edge_list())
     assert es == [(0, 3, {"weight": 2.0, "error_probability": -1, "fault_ids": set()}),
                   (0, 1, {"weight": 3.0, "error_probability": -1, "fault_ids": set()}),
@@ -97,7 +97,7 @@ def test_matching_to_retworkx():
 
     m = Matching()
     m.add_edge(0, 1)
-    g = m.to_retworkx()
+    g = m.to_rustworkx()
     assert list(g.weighted_edge_list()) == [(0, 1, {"weight": 1.0, "error_probability": -1, "fault_ids": set()})]
     assert list(g.nodes()) == [{"is_boundary": False}, {"is_boundary": False}]
 

--- a/tests/matching/properties_test.py
+++ b/tests/matching/properties_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import networkx as nx
-import retworkx as rx
+import rustworkx as rx
 
 from pymatching.matching import Matching
 
@@ -51,12 +51,12 @@ def test_set_min_num_fault_ids():
     g = rx.PyGraph()
     g.add_nodes_from([{} for _ in range(2)])
     g.add_edge(0, 1, dict(fault_ids=3))
-    m.load_from_retworkx(g)
+    m.load_from_rustworkx(g)
     assert m.num_fault_ids == 4
     assert m.decode([1, 1]).shape[0] == 4
-    m.load_from_retworkx(g, min_num_fault_ids=7)
+    m.load_from_rustworkx(g, min_num_fault_ids=7)
     assert m.num_fault_ids == 7
     assert m.decode([1, 1]).shape[0] == 7
-    m.load_from_retworkx(g, min_num_fault_ids=2)
+    m.load_from_rustworkx(g, min_num_fault_ids=2)
     assert m.num_fault_ids == 4
     assert m.decode([1, 1]).shape[0] == 4

--- a/tests/matching/retworkx_test.py
+++ b/tests/matching/retworkx_test.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pymatching import Matching
+import rustworkx as rx
+
+
+def test_load_from_retworkx_deprecated():
+    with pytest.deprecated_call():
+        g = rx.PyGraph()
+        g.add_nodes_from([{} for _ in range(3)])
+        g.add_edge(0, 1, dict(fault_ids=0))
+        g.add_edge(0, 2, dict(fault_ids=1))
+        g.add_edge(1, 2, dict(fault_ids=2))
+        m = Matching()
+        m.load_from_retworkx(g)
+
+
+def test_to_retworkx_deprecated():
+    with pytest.deprecated_call():
+        m = Matching()
+        m.add_edge(0, 1, {0})
+        m.add_edge(1, 2, {1})
+        m.to_retworkx()


### PR DESCRIPTION
Rename retworkx to rustworkx. Methods `Matching.load_from_rustworkx` and `Matching.to_rustworkx` are added, a `DeprecationWarning` has been added to `Matching.load_from_retworkx` and `Matching.to_retworkx`. Fixes #62.