### PR TITLE
Removes python.system_packages from .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,6 @@ python:
     - requirements: docs/sphinx_docs/requirements.txt
     - method: pip
       path: .
-  system_packages: true
 
 submodules:
   include: all


### PR DESCRIPTION
See: https://blog.readthedocs.com/drop-support-system-packages/