### PR TITLE
Fix version inconsistency between artifacts upload and download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,4 +264,6 @@ jobs:
   #         # unpacks all CIBW artifacts into dist/
   #         pattern: cibw-*
   #         path: dist
+  #         merge-multiple: true
+  #
   #     - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           # unpacks all CIBW artifacts into dist/
           pattern: cibw-*


### PR DESCRIPTION
According to [download-artifact](https://github.com/actions/download-artifact):

> Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.

And since `upload-artifact@v4` did not support uploading to the same named Artifact multiple times, we should degrade the version of download-artifact from v4 to v3.