### PR TITLE
Support Numpy v2 and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install g++-11 (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq gcc-11 g++-11
       - run: CC=gcc-11 CXX=g++-11 cmake .
         if: matrix.os == 'ubuntu-latest'
       - run: cmake .
@@ -172,6 +177,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Install g++-11 (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq gcc-11 g++-11
       - run: CC=gcc-11 CXX=g++-11 cmake .
         if: matrix.os == 'ubuntu-latest'
       - run: cmake .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -22,7 +22,7 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         path: dist/*.tar.gz
 
@@ -113,7 +113,7 @@ jobs:
 #          {os: ubuntu-latest, dist: cp311-musllinux_i686},
         ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
     
@@ -132,13 +132,13 @@ jobs:
       shell: bash
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: wheelhouse/*.whl
   benchmark_windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: cmake .
@@ -151,7 +151,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: CC=gcc-10 CXX=g++-10 cmake .
@@ -167,7 +167,7 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: CC=gcc-10 CXX=g++-10 cmake .
@@ -186,7 +186,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -215,7 +215,7 @@ jobs:
   build_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -237,7 +237,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: sdist
+        name: dist-sdist
         path: dist/*.tar.gz
 
 
@@ -139,8 +139,17 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.os_dist.dist }}
+        name: dist-${{ matrix.os_dist.dist }}
         path: wheelhouse/*.whl
+  merge_upload_artifacts:
+    needs: ["build_sdist", "build_wheels"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: dist
+          pattern: dist-*
   benchmark_windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,14 @@ jobs:
           {os: macos-latest, dist: cp310-macosx_x86_64},
           {os: macos-latest, dist: cp311-macosx_x86_64},
           {os: macos-latest, dist: cp312-macosx_x86_64},
+          {os: macos-latest, dist: cp313-macosx_x86_64},
           # macosx arm64
           {os: macos-latest, dist: cp38-macosx_arm64},
           {os: macos-latest, dist: cp39-macosx_arm64},
           {os: macos-latest, dist: cp310-macosx_arm64},
           {os: macos-latest, dist: cp311-macosx_arm64},
           {os: macos-latest, dist: cp312-macosx_arm64},
+          {os: macos-latest, dist: cp313-macosx_arm64},
           # macosx universal2
           # {os: macos-latest, dist: cp38-macosx_universal2},
           # {os: macos-latest, dist: cp39-macosx_universal2},
@@ -70,6 +72,7 @@ jobs:
           {os: windows-latest, dist: cp310-win_amd64},
           {os: windows-latest, dist: cp311-win_amd64},
           {os: windows-latest, dist: cp312-win_amd64},
+          {os: windows-latest, dist: cp313-win_amd64},
           # windows win32
           # {os: windows-latest, dist: cp36-win32},
           {os: windows-latest, dist: cp37-win32},
@@ -91,6 +94,7 @@ jobs:
           {os: ubuntu-latest, dist: cp310-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp311-manylinux_x86_64},
           {os: ubuntu-latest, dist: cp312-manylinux_x86_64},
+          {os: ubuntu-latest, dist: cp313-manylinux_x86_64},
           # ubuntu i686
           # {os: ubuntu-latest, dist: cp36-manylinux_i686},
           {os: ubuntu-latest, dist: cp37-manylinux_i686},
@@ -118,7 +122,7 @@ jobs:
       with:
         submodules: true
     
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
 
     - name: Install g++
       if: runner.os == 'Linux'
@@ -126,7 +130,7 @@ jobs:
         sudo apt update
         sudo apt install gcc-11 g++-11
 
-    - uses: pypa/cibuildwheel@v2.16.5
+    - uses: pypa/cibuildwheel@v2.23.2
 
     - name: Verify clean directory
       run: git diff --exit-code
@@ -202,7 +206,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -231,7 +235,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
 
       - name: Install pandoc
         run: |
@@ -252,7 +256,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Add requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: sdist
         path: dist/*.tar.gz
 
 
@@ -134,6 +135,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
+        name: wheels-${{ matrix.os_dist.dist }}
         path: wheelhouse/*.whl
   benchmark_windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt update
-        sudo apt install gcc-10 g++-10
+        sudo apt install gcc-11 g++-11
 
     - uses: pypa/cibuildwheel@v2.16.5
 
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: CC=gcc-10 CXX=g++-10 cmake .
+      - run: CC=gcc-11 CXX=g++-11 cmake .
         if: matrix.os == 'ubuntu-latest'
       - run: cmake .
         if: matrix.os == 'macos-latest'
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - run: CC=gcc-10 CXX=g++-10 cmake .
+      - run: CC=gcc-11 CXX=g++-11 cmake .
         if: matrix.os == 'ubuntu-latest'
       - run: cmake .
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,8 @@ jobs:
         submodules: true
     
     - uses: actions/setup-python@v5
-
+      with:
+        python-version: '3.x'
     - name: Install g++
       if: runner.os == 'Linux'
       run: |
@@ -206,7 +207,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.13"]
 
     runs-on: ${{ matrix.platform }}
 
@@ -245,6 +246,8 @@ jobs:
           submodules: true
 
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
       - name: Install pandoc
         run: |
@@ -267,7 +270,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Add requirements
         run: python -m pip install --upgrade cmake>=3.12 ninja pytest flake8 pytest-cov stim rustworkx
       - name: Build and install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
   build_wheels:
     runs-on: ${{ matrix.os_dist.os }}
     env:
-      MACOSX_DEPLOYMENT_TARGET: "10.15"
       CIBW_BUILD: "${{ matrix.os_dist.dist }}"
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       CIBW_BEFORE_BUILD: pip install --upgrade ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         os_dist: [
           # macosx x86_64
           # {os: macos-latest, dist: cp36-macosx_x86_64},
-          {os: macos-latest, dist: cp37-macosx_x86_64},
+          # {os: macos-latest, dist: cp37-macosx_x86_64},
           {os: macos-latest, dist: cp38-macosx_x86_64},
           {os: macos-latest, dist: cp39-macosx_x86_64},
           {os: macos-latest, dist: cp310-macosx_x86_64},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
   build_wheels:
     runs-on: ${{ matrix.os_dist.os }}
     env:
+      MACOSX_DEPLOYMENT_TARGET: "11.0"
       CIBW_BUILD: "${{ matrix.os_dist.dist }}"
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       CIBW_BEFORE_BUILD: pip install --upgrade ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ FetchContent_MakeAvailable(googletest)
 
 FetchContent_Declare(stim
         GIT_REPOSITORY https://github.com/quantumlib/Stim.git 
-        GIT_TAG da4594c5ede00a063ec2b84bd830f846b5d097dd)
+        GIT_TAG 1320ad7eac7de34d2e9c70daa44fbc6d84174450)
 FetchContent_MakeAvailable(stim)
 if (NOT (MSVC))
     target_compile_options(libstim PRIVATE -fno-strict-aliasing -fPIC ${ARCH_OPT})

--- a/data/tagged_circuit.stim
+++ b/data/tagged_circuit.stim
@@ -1,0 +1,4 @@
+R[test1] 0
+X_ERROR[test2](0.25) 0
+M[test3](0.25) 0
+DETECTOR[test4](1, 2) rec[-1]

--- a/data/tagged_dem.dem
+++ b/data/tagged_dem.dem
@@ -1,0 +1,3 @@
+error[test2](0.25) D0
+error[test3](0.25) D0
+detector[test4](1, 2) D0

--- a/docs/sphinx_docs/requirements.txt
+++ b/docs/sphinx_docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=8.2.3
+sphinx>=8.1
 sphinx-rtd-theme>=3.0.2
 numpydoc>=1.8.0
 nbsphinx>=0.9.7

--- a/docs/sphinx_docs/requirements.txt
+++ b/docs/sphinx_docs/requirements.txt
@@ -1,7 +1,7 @@
-sphinx==5.3.0
-sphinx-rtd-theme==1.0.0
-numpydoc==1.5.0
-nbsphinx==0.8.9
+sphinx>=8.2.3
+sphinx-rtd-theme>=3.0.2
+numpydoc>=1.8.0
+nbsphinx>=0.9.7
 ipython
-sphinx_mdinclude==0.5.3
-nbsphinx-link==1.3.0
+sphinx_mdinclude>=0.6.2
+nbsphinx-link>=1.3.1

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
         'console_scripts': ['pymatching=pymatching._cli_argv:cli_argv'],
     },
     python_requires=">=3.7",
-    install_requires=['scipy', 'numpy==1.*', 'networkx', 'matplotlib'],
+    install_requires=['scipy', 'numpy', 'networkx', 'matplotlib'],
     # Needed on Windows to avoid the default `build` colliding with Bazel's `BUILD`.
     options={'build': {'build_base': 'python_build_stim'}},
 )

--- a/setup.py
+++ b/setup.py
@@ -108,9 +108,9 @@ class CMakeBuild(build_ext):
                 if arch:
                     cmake_args += [f"-DCMAKE_OSX_ARCHITECTURES={platform.machine()}"]
 
-        if sys.platform.startswith('linux') and which("gcc-10") is not None and which("g++-10") is not None:
-            os.environ["CC"] = "gcc-10"
-            os.environ["CXX"] = "g++-10"
+        if sys.platform.startswith('linux') and which("gcc-11") is not None and which("g++-11") is not None:
+            os.environ["CC"] = "gcc-11"
+            os.environ["CXX"] = "g++-11"
 
         # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
         # across all generators.

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -14,6 +14,7 @@
 
 from typing import Union, List, TYPE_CHECKING, Tuple, Set, Dict, Optional
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pymatching
@@ -1241,7 +1242,7 @@ class Matching:
         return m
 
     @staticmethod
-    def from_detector_error_model_file(dem_path: str) -> 'pymatching.Matching':
+    def from_detector_error_model_file(dem_path: Union[str, Path]) -> 'pymatching.Matching':
         """
         Construct a `pymatching.Matching` by loading from a stim DetectorErrorModel file path.
 
@@ -1256,6 +1257,8 @@ class Matching:
             A `pymatching.Matching` object representing the graphlike error mechanisms in the stim DetectorErrorModel
             in the file `dem_path`
         """
+        if isinstance(dem_path, Path):
+            dem_path = str(dem_path)
         m = Matching()
         m._matching_graph = _cpp_pm.detector_error_model_file_to_matching_graph(dem_path)
         return m
@@ -1308,7 +1311,7 @@ class Matching:
         return m
 
     @staticmethod
-    def from_stim_circuit_file(stim_circuit_path: str) -> 'pymatching.Matching':
+    def from_stim_circuit_file(stim_circuit_path: Union[str, Path]) -> 'pymatching.Matching':
         """
         Construct a `pymatching.Matching` by loading from a stim circuit file path.
 
@@ -1324,6 +1327,8 @@ class Matching:
             in the file `stim_circuit_path`, with any hyperedge error mechanisms decomposed into graphlike error
             mechanisms. Parallel edges are merged using `merge_strategy="independent"`.
         """
+        if isinstance(stim_circuit_path, Path):
+            stim_circuit_path = str(stim_circuit_path)
         m = Matching()
         m._matching_graph = _cpp_pm.stim_circuit_file_to_matching_graph(stim_circuit_path)
         return m

--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.perf.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.perf.cc
@@ -243,7 +243,7 @@ BENCHMARK(Decode_surface_r21_d21_p100_with_dijkstra) {
     auto data = generate_data(21, rounds, 0.01, 8);
     auto &dem = data.first;
     // Add fake observable > 64 to trigger general decoder with Dijkstra post-processing
-    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128));
+    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128), "");
     const auto &shots = data.second;
 
     size_t num_buckets = pm::NUM_DISTINCT_WEIGHTS;
@@ -336,7 +336,7 @@ BENCHMARK(Decode_surface_r21_d21_p1000_with_dijkstra) {
     auto data = generate_data(21, rounds, 0.001, 256);
     auto &dem = data.first;
     // Add fake observable > 64 to trigger general decoder with Dijkstra post-processing
-    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128));
+    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128), "");
     const auto &shots = data.second;
 
     size_t num_buckets = pm::NUM_DISTINCT_WEIGHTS;
@@ -430,7 +430,7 @@ BENCHMARK(Decode_surface_r21_d21_p10000_with_dijkstra) {
     auto data = generate_data(21, rounds, 0.0001, 512);
     auto &dem = data.first;
     // Add fake observable > 64 to trigger general decoder with Dijkstra post-processing
-    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128));
+    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128), "");
     const auto &shots = data.second;
 
     size_t num_buckets = pm::NUM_DISTINCT_WEIGHTS;
@@ -524,7 +524,7 @@ BENCHMARK(Decode_surface_r21_d21_p100000_with_dijkstra) {
     auto data = generate_data(21, rounds, 0.00001, 512);
     auto &dem = data.first;
     // Add fake observable > 64 to trigger general decoder with Dijkstra post-processing
-    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128));
+    dem.append_logical_observable_instruction(stim::DemTarget::observable_id(128), "");
     const auto &shots = data.second;
 
     size_t num_buckets = pm::NUM_DISTINCT_WEIGHTS;

--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
@@ -131,7 +131,7 @@ TEST(MwpmDecoding, CompareSolutionWeightsWithNoLimitOnNumObservables) {
             pm::weight_int num_distinct_weights = 10001;
             if (i == 1)
                 test_case.detector_error_model.append_logical_observable_instruction(
-                    stim::DemTarget::observable_id(128));
+                    stim::DemTarget::observable_id(128), "");
             auto mwpm = pm::detector_error_model_to_mwpm(test_case.detector_error_model, num_distinct_weights);
 
             stim::SparseShot sparse_shot;
@@ -301,7 +301,7 @@ TEST(MwpmDecoding, CompareSolutionObsWithMaxNumBuckets) {
         auto test_case = load_surface_code_d13_p100_test_case();
         pm::weight_int num_distinct_weights = 1 << (sizeof(pm::weight_int) * 8 - 4);
         if (i == 1)
-            test_case.detector_error_model.append_logical_observable_instruction(stim::DemTarget::observable_id(128));
+            test_case.detector_error_model.append_logical_observable_instruction(stim::DemTarget::observable_id(128), "");
         auto mwpm = pm::detector_error_model_to_mwpm(test_case.detector_error_model, num_distinct_weights);
 
         stim::SparseShot sparse_shot;

--- a/tests/matching/load_from_stim_test.py
+++ b/tests/matching/load_from_stim_test.py
@@ -78,3 +78,11 @@ def test_load_from_dem_without_stim_raises_type_error():
             Matching.from_detector_error_model("test")
         with pytest.raises(TypeError):
             Matching.from_stim_circuit("test")
+
+
+def test_load_from_tagged_stim_circuit(data_dir: Path):
+    Matching.from_stim_circuit_file(data_dir / "tagged_circuit.stim")
+
+
+def test_load_from_tagged_detector_error_model(data_dir: Path):
+    Matching.from_detector_error_model_file(data_dir / "tagged_dem.dem")


### PR DESCRIPTION
This PR:
* Adds support for Numpy v2
* Includes pre-built binaries for Python v3.13
* Adds support for loading stim circuits and DEMs with tags by bumping the stim C++ dependency version
* Adds minor API improvements (e.g. supporting pathlib.Path)
* Removes pre-built binaries for Python 3.7 on macos