### PR TITLE
Add method to iterate through a DEM which decomposes Hyper Edges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(PERF_FILES
         src/pymatching/perf/main.perf.cc
         src/pymatching/perf/util.perf.cc
         src/pymatching/sparse_blossom/driver/mwpm_decoding.perf.cc
+        src/pymatching/sparse_blossom/driver/user_graph.perf.cc
         src/pymatching/sparse_blossom/flooder_matcher_interop/varying.perf.cc
         src/pymatching/sparse_blossom/tracker/radix_heap_queue.perf.cc
         )

--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -390,10 +390,10 @@ pm::UserGraph pm::detector_error_model_to_user_graph(
     pm::UserGraph user_graph(detector_error_model.count_detectors(), detector_error_model.count_observables());
     if (enable_correlations) {
         // TODO: Support correlated matching.
-        pm::iter_detector_error_model_edges(
+        pm::iter_dem_instructions_include_correlations(
             detector_error_model,
             [&](double p, const std::vector<size_t>& detectors, std::vector<size_t>& observables) {
-                user_graph.handle_dem_instruction(p, detectors, observables);
+                return;
             });
     } else {
         pm::iter_detector_error_model_edges(

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -290,7 +290,7 @@ void iter_dem_instructions_include_correlations(
             handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
         }
 
-        // TODO: Add error to conditional groups.
+        // TODO: Capture information from decomposed_error into correlation data structure here.
     });
 }
 

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -252,15 +252,15 @@ void iter_dem_instructions_include_correlations(
         // Mark component as empty to begin with.
         component->node1 = SIZE_MAX;
         component->node2 = SIZE_MAX;
-        size_t num_translated_relative_detectors = 0;
+        size_t num_component_detectors = 0;
         for (auto& target : instruction.target_data) {
             // Decompose error
             if (target.is_relative_detector_id()) {
-                num_translated_relative_detectors++;
-                if (num_translated_relative_detectors == 1) {
+                num_component_detectors++;
+                if (num_component_detectors == 1) {
                     const size_t& d1 = target.raw_id();
                     component->node1 = d1;
-                } else if (num_translated_relative_detectors == 2) {
+                } else if (num_component_detectors == 2) {
                     component->node2 = target.raw_id();
                 } else {
                     // We mark errors which have 3 or more detectors as a special boundary-to-boundary edge.
@@ -280,7 +280,7 @@ void iter_dem_instructions_include_correlations(
                 component = &decomposed_err.components.back();
                 component->node1 = SIZE_MAX;
                 component->node2 = SIZE_MAX;
-                num_translated_relative_detectors = 0;
+                num_component_detectors = 0;
             }
         }
         // If the final error in the decomposition had 3 or more components, we ignore it.

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -228,6 +228,72 @@ void iter_detector_error_model_edges(
     });
 }
 
+struct DecomposedDemError {
+    /// The probability of this error occurring.
+    double probability;
+    /// Effects of the error.
+    stim::FixedCapVector<UserEdge, 8> components;
+
+    bool operator==(const DecomposedDemError& other) const;
+    bool operator!=(const DecomposedDemError& other) const;
+};
+
+// TODO: Capture information about correlations.
+template <typename Handler>
+void iter_dem_instructions_include_correlations(
+    const stim::DetectorErrorModel& detector_error_model, const Handler& handle_dem_error) {
+    detector_error_model.iter_flatten_error_instructions([&](const stim::DemInstruction& instruction) {
+        double p = instruction.arg_data[0];
+        pm::DecomposedDemError decomposed_err;
+        decomposed_err.probability = p;
+        decomposed_err.components = {};
+        decomposed_err.components.push_back({});
+        UserEdge* component = &decomposed_err.components.back();
+        // Mark component as empty to begin with.
+        component->node1 = SIZE_MAX;
+        component->node2 = SIZE_MAX;
+        size_t num_translated_relative_detectors = 0;
+        for (auto& target : instruction.target_data) {
+            // Decompose error
+            if (target.is_relative_detector_id()) {
+                num_translated_relative_detectors++;
+                if (num_translated_relative_detectors == 1) {
+                    const size_t& d1 = target.raw_id();
+                    component->node1 = d1;
+                } else if (num_translated_relative_detectors == 2) {
+                    component->node2 = target.raw_id();
+                } else {
+                    // We mark errors which have 3 or more detectors as a special boundary-to-boundary edge.
+                    component->node1 = SIZE_MAX;
+                    component->node2 = SIZE_MAX;
+                }
+            } else if (target.is_observable_id()) {
+                component->observable_indices.push_back(target.val());
+            } else if (target.is_separator()) {
+                // If the previous error in the decomposition had 3 or more components, we ignore it.
+                if (component->node1 == SIZE_MAX) {
+                    decomposed_err.components.pop_back();
+                } else if (p > 0) {
+                    handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+                }
+                decomposed_err.components.push_back({});
+                component = &decomposed_err.components.back();
+                component->node1 = SIZE_MAX;
+                component->node2 = SIZE_MAX;
+                num_translated_relative_detectors = 0;
+            }
+        }
+        // If the final error in the decomposition had 3 or more components, we ignore it.
+        if (component->node1 == SIZE_MAX) {
+            decomposed_err.components.pop_back();
+        } else if (p > 0) {
+            handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+        }
+
+        // TODO: Add error to conditional groups.
+    });
+}
+
 }  // namespace pm
 
 #endif  // PYMATCHING2_USER_GRAPH_H

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -277,7 +277,6 @@ TEST(IterDemInstructionsTest, DecomposedError) {
     pm::iter_dem_instructions_include_correlations(dem, handler);
     ASSERT_EQ(handler.handled_errors.size(), 3);
 
-    // std::vector<HandledError> expected = {{0.1, 0, 1, {}}, {0.1, 2, 3, {0}}, {0.1, 4, SIZE_MAX, {}}};
     EXPECT_EQ(handler.handled_errors[0], (HandledError{0.1, 0, 1, {}}));
     EXPECT_EQ(handler.handled_errors[1], (HandledError{0.1, 2, 3, {0}}));
     EXPECT_EQ(handler.handled_errors[2], (HandledError{0.1, 4, SIZE_MAX, {}}));
@@ -321,7 +320,5 @@ TEST(IterDemInstructionsTest, CombinedComplexDem) {
         {0.4, 8, SIZE_MAX, {}},
         {0.4, 9, SIZE_MAX, {1}}};
 
-    // stim's iter_flatten_error_instructions processes instructions sequentially,
-    // so the order of handled errors should be deterministic.
     EXPECT_EQ(handler.handled_errors, expected);
 }

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -305,12 +305,6 @@ TEST(IterDemInstructionsTest, CombinedComplexDem) {
     TestHandler handler;
     pm::iter_dem_instructions_include_correlations(dem, handler);
 
-    // We expect 5 errors to be handled from this model.
-    // 1. {0.1, 0, MAX, {}} from "error(0.1) D0"
-    // 2. {0.2, 1, 2, {0}} from "error(0.2) D1 D2 L0"
-    // 3. {0.3, 6, MAX, {}} from the second part of "error(0.3) D3 D4 D5 ^ D6" (first part is ignored)
-    // 4. {0.4, 8, MAX, {}} from the first part of "error(0.4) D8 ^ D9 L1"
-    // 5. {0.4, 9, MAX, {1}} from the second part of "error(0.4) D8 ^ D9 L1"
     ASSERT_EQ(handler.handled_errors.size(), 5);
 
     std::vector<HandledError> expected = {

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -19,6 +19,21 @@
 
 #include "pymatching/sparse_blossom/driver/mwpm_decoding.h"
 
+double merge_weights_via_probabilities(double a, double b) {
+    double p_a = 1 / (1 + std::exp(a));
+    double p_b = 1 / (1 + std::exp(b));
+    double p_both = p_a * (1 - p_b) + p_b * (1 - p_a);
+    return std::log((1 - p_both) / p_both);
+}
+
+TEST(StimIO, MergeWeights) {
+    ASSERT_FLOAT_EQ(merge_weights_via_probabilities(10, 11), pm::merge_weights(10, 11));
+    ASSERT_FLOAT_EQ(merge_weights_via_probabilities(-4.1, 5), pm::merge_weights(-4.1, 5));
+    ASSERT_FLOAT_EQ(merge_weights_via_probabilities(25, -24), pm::merge_weights(25, -24));
+    ASSERT_FLOAT_EQ(merge_weights_via_probabilities(-1, -2), pm::merge_weights(-1, -2));
+    ASSERT_FLOAT_EQ(pm::merge_weights(1000, 0), 0);
+}
+
 TEST(UserGraph, ConstructGraph) {
     pm::UserGraph graph;
     graph.add_or_merge_boundary_edge(0, {2}, 4.1, 0.1);
@@ -165,4 +180,148 @@ TEST(UserGraph, DecodeUserGraphDetectionEventOnBoundaryNode) {
         pm::ExtendedMatchingResult res(mwpm.flooder.graph.num_observables);
         pm::decode_detection_events(mwpm, {2}, res.obs_crossed.data(), res.weight);
     }
+}
+
+/// Tests for iter_dem_instructions_include_correlations
+
+/// A helper struct to capture the data passed to the handler function for later validation in tests.
+struct HandledError {
+    double probability;
+    size_t node1;
+    size_t node2;
+    std::vector<size_t> observables;
+
+    // Equality operator for easy comparison with ASSERT_EQ.
+    bool operator==(const HandledError& other) const {
+        return probability == other.probability && node1 == other.node1 && node2 == other.node2 &&
+               observables == other.observables;
+    }
+};
+
+struct TestHandler {
+    mutable std::vector<HandledError> handled_errors;
+
+    void operator()(double p, const std::vector<size_t> dets, const std::vector<size_t>& observables) const {
+        if (dets.size() == 1) {
+            handled_errors.push_back({p, dets[0], SIZE_MAX, observables});
+        } else if (dets.size() == 2) {
+            handled_errors.push_back({p, dets[0], dets[1], observables});
+        }
+    }
+};
+
+// Test with an empty detector error model. The handler should not be called.
+TEST(IterDemInstructionsTest, EmptyDem) {
+    stim::DetectorErrorModel dem;
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_TRUE(handler.handled_errors.empty());
+}
+
+// Test a simple error involving one detector, which is an error on the boundary.
+TEST(IterDemInstructionsTest, SingleDetectorErrorToBoundary) {
+    stim::DetectorErrorModel dem("error(0.1) D0");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 1);
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.1, 0, SIZE_MAX, {}}));
+}
+
+// Test a standard error between two detectors.
+TEST(IterDemInstructionsTest, TwoDetectorError) {
+    stim::DetectorErrorModel dem("error(0.25) D5 D10");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 1);
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.25, 5, 10, {}}));
+}
+
+// Test an error that also flips a logical observable.
+TEST(IterDemInstructionsTest, ErrorWithOneObservable) {
+    stim::DetectorErrorModel dem("error(0.125) D1 D2 L0");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 1);
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.125, 1, 2, {0}}));
+}
+
+// Test an error that flips multiple logical observables.
+TEST(IterDemInstructionsTest, ErrorWithMultipleObservables) {
+    stim::DetectorErrorModel dem("error(0.3) D3 D4 L1 L3");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 1);
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.3, 3, 4, {1, 3}}));
+}
+
+// Test an error with probability 0. It should be ignored.
+TEST(IterDemInstructionsTest, ZeroProbabilityError) {
+    stim::DetectorErrorModel dem("error(0.0) D0 D1");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_TRUE(handler.handled_errors.empty());
+}
+
+// Test an error involving more than two detectors (a hyperedge). This should be ignored.
+TEST(IterDemInstructionsTest, ThreeDetectorErrorIsIgnored) {
+    stim::DetectorErrorModel dem("error(0.1) D0 D1 D2");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_TRUE(handler.handled_errors.empty());
+}
+
+// Test a decomposed error instruction. The handler should be called for each component.
+TEST(IterDemInstructionsTest, DecomposedError) {
+    stim::DetectorErrorModel dem("error(0.1) D0 D1 ^ D2 D3 L0 ^ D4");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 3);
+
+    // std::vector<HandledError> expected = {{0.1, 0, 1, {}}, {0.1, 2, 3, {0}}, {0.1, 4, SIZE_MAX, {}}};
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.1, 0, 1, {}}));
+    EXPECT_EQ(handler.handled_errors[1], (HandledError{0.1, 2, 3, {0}}));
+    EXPECT_EQ(handler.handled_errors[2], (HandledError{0.1, 4, SIZE_MAX, {}}));
+}
+
+// Test a decomposed error where one of the components is a hyperedge and should be ignored.
+TEST(IterDemInstructionsTest, DecomposedErrorWithIgnoredComponent) {
+    stim::DetectorErrorModel dem("error(0.15) D0 D1 ^ D2 D3 D4 ^ D5 D6 L2");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+    ASSERT_EQ(handler.handled_errors.size(), 2);
+
+    std::vector<HandledError> expected = {{0.15, 0, 1, {}}, {0.15, 5, 6, {2}}};
+    EXPECT_EQ(handler.handled_errors, expected);
+}
+
+// Test a complex DEM with multiple instruction types and edge cases combined.
+TEST(IterDemInstructionsTest, CombinedComplexDem) {
+    stim::DetectorErrorModel dem(R"DEM(
+        error(0.1) D0            # Instruction 1: Simple
+        error(0.2) D1 D2 L0      # Instruction 2: Two detectors, one observable
+        error(0.3) D3 D4 D5 ^ D6 # Instruction 3: Hyperedge ignored, second component handled
+        error(0.0) D7            # Instruction 4: Zero probability, ignored
+        error(0.4) D8 ^ D9 L1    # Instruction 5: Decomposed
+    )DEM");
+    TestHandler handler;
+    pm::iter_dem_instructions_include_correlations(dem, handler);
+
+    // We expect 5 errors to be handled from this model.
+    // 1. {0.1, 0, MAX, {}} from "error(0.1) D0"
+    // 2. {0.2, 1, 2, {0}} from "error(0.2) D1 D2 L0"
+    // 3. {0.3, 6, MAX, {}} from the second part of "error(0.3) D3 D4 D5 ^ D6" (first part is ignored)
+    // 4. {0.4, 8, MAX, {}} from the first part of "error(0.4) D8 ^ D9 L1"
+    // 5. {0.4, 9, MAX, {1}} from the second part of "error(0.4) D8 ^ D9 L1"
+    ASSERT_EQ(handler.handled_errors.size(), 5);
+
+    std::vector<HandledError> expected = {
+        {0.1, 0, SIZE_MAX, {}},
+        {0.2, 1, 2, {0}},
+        {0.3, 6, SIZE_MAX, {}},
+        {0.4, 8, SIZE_MAX, {}},
+        {0.4, 9, SIZE_MAX, {1}}};
+
+    // stim's iter_flatten_error_instructions processes instructions sequentially,
+    // so the order of handled errors should be deterministic.
+    EXPECT_EQ(handler.handled_errors, expected);
 }


### PR DESCRIPTION
This PR introduces `iter_dem_instructions_include_correlations`, a helper method that iterates through `error` instructions in the DEM and processes components of a suggested decomposition (with fewer than 3 detectors) of a hyper edge as per a user-provided handler. In a future PR, this method will be used to capture information about correlations between decomposed error mechanisms.

It also re-adds in tests for `merge_weights` that were removed erroneously in a prior change.

We also establish a baseline for loading a DEM with correlated information included:

```
[.................*<<|....................] 530 us (vs 290 us) (2.8 Mdets/s) (9.5 Mlayers/s) (1.9 Mshots/s) Decode_surface_r5_d5_p1000
[................*<<<|....................]  23 ms (vs  10 ms) (920 kdets/s) ( 59 klayers/s) (5.3 kshots/s) Decode_surface_r11_d11_p100
[................*<<<|....................] 3.4 ms (vs 1.5 ms) (2.9 Mdets/s) (1.6 Mlayers/s) (140 kshots/s) Decode_surface_r11_d11_p1000
[..................*<|....................] 140 us (vs  83 us) (3.6 Mdets/s) ( 19 Mlayers/s) (1.7 Mshots/s) Decode_surface_r11_d11_p10000
[..................*<|....................]  56 us (vs  33 us) (3.3 Mdets/s) (190 Mlayers/s) ( 18 Mshots/s) Decode_surface_r11_d11_p100000
[................*<<<|....................]  16 ms (vs 7.5 ms) (600 kdets/s) (9.9 klayers/s) (470 shots/s) Decode_surface_r21_d21_p100
[...............*<<<<|....................]  23 ms (vs 7.8 ms) (430 kdets/s) (7.1 klayers/s) (330 shots/s) Decode_surface_r21_d21_p100_with_dijkstra
[...............*<<<<|....................]  24 ms (vs 8.2 ms) (410 kdets/s) (6.8 klayers/s) (320 shots/s) Decode_surface_r21_d21_p100_to_edges
[.................*<<|....................]  13 ms (vs 6.3 ms) (2.7 Mdets/s) (390 klayers/s) ( 18 kshots/s) Decode_surface_r21_d21_p1000
[..............*<<<<<|....................]  28 ms (vs 7.7 ms) (1.2 Mdets/s) (180 klayers/s) (8.9 kshots/s) Decode_surface_r21_d21_p1000_with_dijkstra
[..............*<<<<<|....................]  30 ms (vs 8.4 ms) (1.1 Mdets/s) (170 klayers/s) (8.2 kshots/s) Decode_surface_r21_d21_p1000_to_edges
[................*<<<|....................] 2.4 ms (vs 980 us) (3.2 Mdets/s) (4.4 Mlayers/s) (210 kshots/s) Decode_surface_r21_d21_p10000
[..............*<<<<<|....................] 5.0 ms (vs 1.3 ms) (1.5 Mdets/s) (2.1 Mlayers/s) (100 kshots/s) Decode_surface_r21_d21_p10000_with_dijkstra
[..............*<<<<<|....................] 5.4 ms (vs 1.4 ms) (1.4 Mdets/s) (1.9 Mlayers/s) ( 94 kshots/s) Decode_surface_r21_d21_p10000_to_edges
[.................*<<|....................] 180 us (vs  94 us) (3.9 Mdets/s) ( 58 Mlayers/s) (2.7 Mshots/s) Decode_surface_r21_d21_p100000
[...............*<<<<|....................] 380 us (vs 130 us) (1.8 Mdets/s) ( 27 Mlayers/s) (1.3 Mshots/s) Decode_surface_r21_d21_p100000_with_dijkstra
[...............*<<<<|....................] 430 us (vs 130 us) (1.6 Mdets/s) ( 24 Mlayers/s) (1.1 Mshots/s) Decode_surface_r21_d21_p100000_to_edges
[..................*<|....................]  54 ms (vs  35 ms) (180 loads/s) Load_dem_r11_d11_p100
[..................*<|....................] 450 ms (vs 280 ms) ( 22 loads/s) Load_dem_r21_d21_p100
[....................|>*..................]  24 ms (vs  35 ms) (410 loads/s) Load_dem_r11_d11_p100_correlations
[....................|>*..................] 170 ms (vs 280 ms) ( 57 loads/s) Load_dem_r21_d21_p100_correlations
[................*<<<|....................] 9.7 ms (vs 3.5 ms) (1.0 Gcalls/s) Varying32_get_distance_at_time
[..............*<<<<<|....................]  22 ms (vs 5.9 ms) (450 Mcalls/s) Varying64_get_distance_at_time
[....................*....................] 4.8 us (vs 4.9 us) (200 MEnqueueDequeues/s) bucket_queue_sort
[..................*<|....................] 140 us (vs  99 us) ( 67 MEnqueueDequeues/s) bucket_queue_stream
```