### PR TITLE
Track joint probabilities of correlated errors

### DIFF
--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -401,8 +401,10 @@ void pm::add_decomposed_error_to_joint_probabilities(
             for (size_t k1 = k0 + 1; k1 < error.components.size(); k1++) {
                 auto& c0 = error.components[k0];
                 auto& c1 = error.components[k1];
-                double& p01 = joint_probabilites[{c0.node1, c0.node2}][{c1.node1, c1.node2}];
-                double& p10 = joint_probabilites[{c1.node1, c1.node2}][{c0.node1, c0.node2}];
+                std::pair<size_t, size_t> e0 = std::minmax(c0.node1, c0.node2);
+                std::pair<size_t, size_t> e1 = std::minmax(c1.node1, c1.node2);
+                double& p01 = joint_probabilites[e0][e1];
+                double& p10 = joint_probabilites[e1][e0];
                 p01 = bernoulli_xor(p01, error.probability);
                 p10 = bernoulli_xor(p10, error.probability);
             }
@@ -410,7 +412,7 @@ void pm::add_decomposed_error_to_joint_probabilities(
     }
 
     for (auto& e : error.components) {
-        double& p = joint_probabilites[{e.node1, e.node2}][{e.node1, e.node2}];
+        double& p = joint_probabilites[std::minmax(e.node1, e.node2)][std::minmax(e.node1, e.node2)];
         p = bernoulli_xor(p, error.probability);
     }
 };

--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -385,16 +385,48 @@ double pm::UserGraph::get_edge_weight_normalising_constant(size_t max_num_distin
     }
 }
 
+namespace {
+
+double bernoulli_xor(double p1, double p2) {
+    return p1 * (1 - p2) + p2 * (1 - p1);
+}
+
+}  // namespace
+
+void pm::add_decomposed_error_to_joint_probabilities(
+    DecomposedDemError& error,
+    std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>>& joint_probabilites) {
+    if (error.components.size() > 1) {
+        for (size_t k0 = 0; k0 < error.components.size(); k0++) {
+            for (size_t k1 = k0 + 1; k1 < error.components.size(); k1++) {
+                auto& c0 = error.components[k0];
+                auto& c1 = error.components[k1];
+                double& p01 = joint_probabilites[{c0.node1, c0.node2}][{c1.node1, c1.node2}];
+                double& p10 = joint_probabilites[{c1.node1, c1.node2}][{c0.node1, c0.node2}];
+                p01 = bernoulli_xor(p01, error.probability);
+                p10 = bernoulli_xor(p10, error.probability);
+            }
+        }
+    }
+
+    for (auto& e : error.components) {
+        double& p = joint_probabilites[{e.node1, e.node2}][{e.node1, e.node2}];
+        p = bernoulli_xor(p, error.probability);
+    }
+};
+
 pm::UserGraph pm::detector_error_model_to_user_graph(
     const stim::DetectorErrorModel& detector_error_model, const bool enable_correlations) {
     pm::UserGraph user_graph(detector_error_model.count_detectors(), detector_error_model.count_observables());
+    std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>> joint_probabilites;
     if (enable_correlations) {
-        // TODO: Support correlated matching.
         pm::iter_dem_instructions_include_correlations(
             detector_error_model,
             [&](double p, const std::vector<size_t>& detectors, std::vector<size_t>& observables) {
                 return;
-            });
+            },
+            joint_probabilites);
+        // TODO: Support correlated matching. Add implied edge weights to the User Graph here.
     } else {
         pm::iter_detector_error_model_edges(
             detector_error_model,
@@ -402,5 +434,6 @@ pm::UserGraph pm::detector_error_model_to_user_graph(
                 user_graph.handle_dem_instruction(p, detectors, observables);
             });
     }
+
     return user_graph;
 }

--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -434,6 +434,5 @@ pm::UserGraph pm::detector_error_model_to_user_graph(
                 user_graph.handle_dem_instruction(p, detectors, observables);
             });
     }
-
     return user_graph;
 }

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -239,10 +239,15 @@ struct DecomposedDemError {
     bool operator!=(const DecomposedDemError& other) const;
 };
 
-// TODO: Capture information about correlations.
+void add_decomposed_error_to_joint_probabilities(
+    DecomposedDemError& error,
+    std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>>& joint_probabilites);
+
 template <typename Handler>
 void iter_dem_instructions_include_correlations(
-    const stim::DetectorErrorModel& detector_error_model, const Handler& handle_dem_error) {
+    const stim::DetectorErrorModel& detector_error_model,
+    const Handler& handle_dem_error,
+    std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>>& joint_probabilites) {
     detector_error_model.iter_flatten_error_instructions([&](const stim::DemInstruction& instruction) {
         double p = instruction.arg_data[0];
         pm::DecomposedDemError decomposed_err;
@@ -250,6 +255,10 @@ void iter_dem_instructions_include_correlations(
         if (p > 0.5) {
             throw ::std::invalid_argument(
                 "Errors with probability greater than 0.5 are not supported with correlations enabled");
+        }
+        if (p == 0) {
+            // Ignore errors with no error probability.
+            return;
         }
         decomposed_err.components = {};
         decomposed_err.components.push_back({});
@@ -297,7 +306,7 @@ void iter_dem_instructions_include_correlations(
             handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
         }
 
-        // TODO: Capture information from decomposed_error into correlation data structure here.
+        add_decomposed_error_to_joint_probabilities(decomposed_err, joint_probabilites);
     });
 }
 

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -275,7 +275,13 @@ void iter_dem_instructions_include_correlations(
                     const size_t& d1 = target.raw_id();
                     component->node1 = d1;
                 } else if (num_component_detectors == 2) {
-                    component->node2 = target.raw_id();
+                    // Maintain invariant that node1 <= node2.
+                    if (component->node1 <= target.raw_id()) {
+                        component->node2 = target.raw_id();
+                    } else {
+                        component->node2 = component->node1;
+                        component->node1 = target.raw_id();
+                    }
                 } else {
                     // We mark errors which have 3 or more detectors as a special boundary-to-boundary edge.
                     component->node1 = SIZE_MAX;

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -253,6 +253,20 @@ TEST(IterDemInstructionsTest, TwoDetectorError) {
     EXPECT_DOUBLE_EQ(joint_probabilities[key][key], 0.25);
 }
 
+// Test a standard error between two detectors where they are not sorted in the DEM.
+TEST(IterDemInstructionsTest, TwoDetectorErrorNotSorted) {
+    stim::DetectorErrorModel dem("error(0.25) D10 D5");
+    TestHandler handler;
+    std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>> joint_probabilities;
+    pm::iter_dem_instructions_include_correlations(dem, handler, joint_probabilities);
+
+    ASSERT_EQ(handler.handled_errors.size(), 1);
+    EXPECT_EQ(handler.handled_errors[0], (HandledError{0.25, 5, 10, {}}));
+
+    std::pair<size_t, size_t> key = {5, 10};
+    EXPECT_DOUBLE_EQ(joint_probabilities[key][key], 0.25);
+}
+
 // Test an error that also flips a logical observable.
 TEST(IterDemInstructionsTest, ErrorWithOneObservable) {
     stim::DetectorErrorModel dem("error(0.125) D1 D2 L0");


### PR DESCRIPTION
This PR extends `iter_dem_instructions_include_correlations` to track the joint probabilities between components that arise from the same error instruction.

The core of this change is the introduction of a `joint_probabilities map` which is populated during the DEM iteration. This map stores the probability of any two error components occurring together.

All existing tests have been updated to pass in the joint_probabilities map and verify its final state.

-- Performance before this PR -- 

```
[.................*<<|....................] 530 us (vs 290 us) (2.8 Mdets/s) (9.5 Mlayers/s) (1.9 Mshots/s) Decode_surface_r5_d5_p1000
[................*<<<|....................]  23 ms (vs  10 ms) (930 kdets/s) ( 59 klayers/s) (5.3 kshots/s) Decode_surface_r11_d11_p100
[................*<<<|....................] 3.4 ms (vs 1.5 ms) (2.9 Mdets/s) (1.6 Mlayers/s) (140 kshots/s) Decode_surface_r11_d11_p1000
[..................*<|....................] 140 us (vs  83 us) (3.6 Mdets/s) ( 19 Mlayers/s) (1.7 Mshots/s) Decode_surface_r11_d11_p10000
[..................*<|....................]  56 us (vs  33 us) (3.3 Mdets/s) (190 Mlayers/s) ( 17 Mshots/s) Decode_surface_r11_d11_p100000
[.................*<<|....................]  16 ms (vs 7.5 ms) (620 kdets/s) ( 10 klayers/s) (480 shots/s) Decode_surface_r21_d21_p100
[................*<<<|....................]  21 ms (vs 7.8 ms) (470 kdets/s) (7.8 klayers/s) (370 shots/s) Decode_surface_r21_d21_p100_with_dijkstra
[................*<<<|....................]  22 ms (vs 8.2 ms) (450 kdets/s) (7.4 klayers/s) (350 shots/s) Decode_surface_r21_d21_p100_to_edges
[.................*<<|....................]  12 ms (vs 6.3 ms) (2.8 Mdets/s) (410 klayers/s) ( 19 kshots/s) Decode_surface_r21_d21_p1000
[...............*<<<<|....................]  25 ms (vs 7.7 ms) (1.4 Mdets/s) (210 klayers/s) ( 10 kshots/s) Decode_surface_r21_d21_p1000_with_dijkstra
[...............*<<<<|....................]  26 ms (vs 8.4 ms) (1.3 Mdets/s) (200 klayers/s) (9.7 kshots/s) Decode_surface_r21_d21_p1000_to_edges
[................*<<<|....................] 2.4 ms (vs 980 us) (3.1 Mdets/s) (4.4 Mlayers/s) (200 kshots/s) Decode_surface_r21_d21_p10000
[...............*<<<<|....................] 4.2 ms (vs 1.3 ms) (1.8 Mdets/s) (2.5 Mlayers/s) (120 kshots/s) Decode_surface_r21_d21_p10000_with_dijkstra
[...............*<<<<|....................] 4.6 ms (vs 1.4 ms) (1.6 Mdets/s) (2.3 Mlayers/s) (110 kshots/s) Decode_surface_r21_d21_p10000_to_edges
[.................*<<|....................] 180 us (vs  94 us) (3.9 Mdets/s) ( 58 Mlayers/s) (2.7 Mshots/s) Decode_surface_r21_d21_p100000
[...............*<<<<|....................] 370 us (vs 130 us) (1.9 Mdets/s) ( 28 Mlayers/s) (1.3 Mshots/s) Decode_surface_r21_d21_p100000_with_dijkstra
[...............*<<<<|....................] 390 us (vs 130 us) (1.8 Mdets/s) ( 26 Mlayers/s) (1.2 Mshots/s) Decode_surface_r21_d21_p100000_to_edges
[..................*<|....................]  53 ms (vs  35 ms) (180 loads/s) Load_dem_r11_d11_p100
[..................*<|....................] 400 ms (vs 280 ms) ( 24 loads/s) Load_dem_r21_d21_p100
[....................|>*..................]  24 ms (vs  35 ms) (400 loads/s) Load_dem_r11_d11_p100_correlations
[....................|>*..................] 170 ms (vs 280 ms) ( 57 loads/s) Load_dem_r21_d21_p100_correlations
[................*<<<|....................] 9.6 ms (vs 3.5 ms) (1.0 Gcalls/s) Varying32_get_distance_at_time
[..............*<<<<<|....................]  25 ms (vs 5.9 ms) (390 Mcalls/s) Varying64_get_distance_at_time
[....................*....................] 4.9 us (vs 4.9 us) (200 MEnqueueDequeues/s) bucket_queue_sort
[..................*<|....................] 140 us (vs  99 us) ( 67 MEnqueueDequeues/s) bucket_queue_stream
```



--   Performance after this PR  --

```
[.................*<<|....................] 530 us (vs 290 us) (2.8 Mdets/s) (9.5 Mlayers/s) (1.9 Mshots/s) Decode_surface_r5_d5_p1000
[................*<<<|....................]  23 ms (vs  10 ms) (930 kdets/s) ( 59 klayers/s) (5.4 kshots/s) Decode_surface_r11_d11_p100
[................*<<<|....................] 3.4 ms (vs 1.5 ms) (2.9 Mdets/s) (1.6 Mlayers/s) (140 kshots/s) Decode_surface_r11_d11_p1000
[..................*<|....................] 140 us (vs  83 us) (3.6 Mdets/s) ( 19 Mlayers/s) (1.8 Mshots/s) Decode_surface_r11_d11_p10000
[..................*<|....................]  56 us (vs  33 us) (3.3 Mdets/s) (190 Mlayers/s) ( 18 Mshots/s) Decode_surface_r11_d11_p100000
[.................*<<|....................]  16 ms (vs 7.5 ms) (630 kdets/s) ( 10 klayers/s) (490 shots/s) Decode_surface_r21_d21_p100
[................*<<<|....................]  21 ms (vs 7.8 ms) (480 kdets/s) (7.8 klayers/s) (370 shots/s) Decode_surface_r21_d21_p100_with_dijkstra
[................*<<<|....................]  22 ms (vs 8.2 ms) (450 kdets/s) (7.4 klayers/s) (350 shots/s) Decode_surface_r21_d21_p100_to_edges
[.................*<<|....................]  12 ms (vs 6.3 ms) (2.8 Mdets/s) (420 klayers/s) ( 20 kshots/s) Decode_surface_r21_d21_p1000
[...............*<<<<|....................]  23 ms (vs 7.7 ms) (1.5 Mdets/s) (220 klayers/s) ( 10 kshots/s) Decode_surface_r21_d21_p1000_with_dijkstra
[...............*<<<<|....................]  26 ms (vs 8.4 ms) (1.3 Mdets/s) (200 klayers/s) (9.6 kshots/s) Decode_surface_r21_d21_p1000_to_edges
[................*<<<|....................] 2.3 ms (vs 980 us) (3.2 Mdets/s) (4.5 Mlayers/s) (210 kshots/s) Decode_surface_r21_d21_p10000
[...............*<<<<|....................] 4.2 ms (vs 1.3 ms) (1.8 Mdets/s) (2.5 Mlayers/s) (120 kshots/s) Decode_surface_r21_d21_p10000_with_dijkstra
[...............*<<<<|....................] 4.5 ms (vs 1.4 ms) (1.6 Mdets/s) (2.3 Mlayers/s) (110 kshots/s) Decode_surface_r21_d21_p10000_to_edges
[.................*<<|....................] 180 us (vs  94 us) (3.9 Mdets/s) ( 58 Mlayers/s) (2.7 Mshots/s) Decode_surface_r21_d21_p100000
[...............*<<<<|....................] 370 us (vs 130 us) (1.9 Mdets/s) ( 28 Mlayers/s) (1.3 Mshots/s) Decode_surface_r21_d21_p100000_with_dijkstra
[...............*<<<<|....................] 390 us (vs 130 us) (1.8 Mdets/s) ( 27 Mlayers/s) (1.3 Mshots/s) Decode_surface_r21_d21_p100000_to_edges
[..................*<|....................]  52 ms (vs  35 ms) (190 loads/s) Load_dem_r11_d11_p100
[...................*|....................] 390 ms (vs 280 ms) ( 25 loads/s) Load_dem_r21_d21_p100
[...................*|....................]  43 ms (vs  35 ms) (230 loads/s) Load_dem_r11_d11_p100_correlations
[...................*|....................] 340 ms (vs 280 ms) ( 29 loads/s) Load_dem_r21_d21_p100_correlations
[................*<<<|....................] 9.6 ms (vs 3.5 ms) (1.0 Gcalls/s) Varying32_get_distance_at_time
[..............*<<<<<|....................]  25 ms (vs 5.9 ms) (390 Mcalls/s) Varying64_get_distance_at_time
[....................*....................] 4.9 us (vs 4.9 us) (200 MEnqueueDequeues/s) bucket_queue_sort
[..................*<|....................] 140 us (vs  99 us) ( 67 MEnqueueDequeues/s) bucket_queue_stream
```