### PR TITLE
Add constraints on DEM validity for correlated matching.

### DIFF
--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -272,7 +272,9 @@ void iter_dem_instructions_include_correlations(
             } else if (target.is_separator()) {
                 // If the previous error in the decomposition had 3 or more components, we ignore it.
                 if (component->node1 == SIZE_MAX) {
-                    decomposed_err.components.pop_back();
+                    throw std::invalid_argument(
+                        "Encountered a decomposed error instruction with a hyperedge component (3 or more detectors). "
+                        "This is not supported.");
                 } else if (p > 0) {
                     handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
                 }

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <list>
 #include <set>
+#include <stdexcept>
 #include <vector>
 
 #include "pymatching/rand/rand_gen.h"
@@ -246,6 +247,10 @@ void iter_dem_instructions_include_correlations(
         double p = instruction.arg_data[0];
         pm::DecomposedDemError decomposed_err;
         decomposed_err.probability = p;
+        if (p > 0.5) {
+            throw ::std::invalid_argument(
+                "Errors with probability greater than 0.5 are not supported with correlations enabled");
+        }
         decomposed_err.components = {};
         decomposed_err.components.push_back({});
         UserEdge* component = &decomposed_err.components.back();

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -16,6 +16,7 @@
 
 #include <cmath>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include "pymatching/sparse_blossom/driver/mwpm_decoding.h"
 
@@ -309,4 +310,11 @@ TEST(IterDemInstructionsTest, CombinedComplexDem) {
         {0.1, 0, SIZE_MAX, {}}, {0.2, 1, 2, {0}}, {0.4, 8, SIZE_MAX, {}}, {0.4, 9, SIZE_MAX, {1}}};
 
     EXPECT_EQ(handler.handled_errors, expected);
+}
+
+// Test that an error greater than 0.5 results in a throw.
+TEST(IterDemInstructionsTest, ProbabilityGreaterThanHalfThrows) {
+    stim::DetectorErrorModel dem("error(0.51) D0 D2");
+    TestHandler handler;
+    ASSERT_THROW(pm::iter_dem_instructions_include_correlations(dem, handler), std::invalid_argument);
 }


### PR DESCRIPTION
Conversion to a user graph with correlations turned on will now throw an exception when:
- An edge decomposition contains a hyperedge
- An edge with probability greater than 0.5 is present in the DEM (we don't support negative edge weights for correlated matching yet).