### PR TITLE
Make previously free edges to implied weights unconverted variable a class member

### DIFF
--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.test.cc
@@ -345,17 +345,12 @@ TEST(MwpmDecoding, HandleAllNegativeWeights) {
         auto mwpm = pm::Mwpm(
             pm::GraphFlooder(pm::MatchingGraph(num_nodes, num_nodes)), pm::SearchFlooder(pm::SearchGraph(num_nodes)));
         auto& g = mwpm.flooder.graph;
-        std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>
-            edges_to_implied_weights_unconverted;
         for (size_t i = 0; i < num_nodes; i++)
-            g.add_edge(i, (i + 1) % num_nodes, -2, {i}, {}, edges_to_implied_weights_unconverted);
+            g.add_edge(i, (i + 1) % num_nodes, -2, {i}, {});
 
         if (num_nodes > sizeof(pm::obs_int) * 8) {
-            std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>
-                edges_to_implied_weights_unconverted;
             for (size_t i = 0; i < num_nodes; i++)
-                mwpm.search_flooder.graph.add_edge(
-                    i, (i + 1) % num_nodes, -2, {i}, {}, edges_to_implied_weights_unconverted);
+                mwpm.search_flooder.graph.add_edge(i, (i + 1) % num_nodes, -2, {i}, {});
         }
 
         mwpm.flooder.sync_negative_weight_observables_and_detection_events();
@@ -393,25 +388,21 @@ TEST(MwpmDecoding, HandleSomeNegativeWeights) {
             pm::GraphFlooder(pm::MatchingGraph(num_nodes, max_obs + 1)), pm::SearchFlooder(pm::SearchGraph(num_nodes)));
 
         auto& g = mwpm.flooder.graph;
-        std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>
-            edges_to_implied_weights_unconverted;
-        g.add_boundary_edge(0, -4, {max_obs}, {}, edges_to_implied_weights_unconverted);
+        g.add_boundary_edge(0, -4, {max_obs}, {});
         for (size_t i = 0; i < 7; i += 2)
-            g.add_edge(i, i + 1, 2, {i + 1}, {}, edges_to_implied_weights_unconverted);
+            g.add_edge(i, i + 1, 2, {i + 1}, {});
         for (size_t i = 1; i < 7; i += 2)
-            g.add_edge(i, i + 1, -4, {i + 1}, {}, edges_to_implied_weights_unconverted);
-        g.add_boundary_edge(7, 2, {num_nodes}, {}, edges_to_implied_weights_unconverted);
+            g.add_edge(i, i + 1, -4, {i + 1}, {});
+        g.add_boundary_edge(7, 2, {num_nodes}, {});
 
         if (max_obs > sizeof(pm::obs_int) * 8) {
             auto& h = mwpm.search_flooder.graph;
-            std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>
-                edges_to_implied_weights_unconverted;
-            h.add_boundary_edge(0, -4, {max_obs}, {}, edges_to_implied_weights_unconverted);
+            h.add_boundary_edge(0, -4, {max_obs}, {});
             for (size_t i = 0; i < 7; i += 2)
-                h.add_edge(i, i + 1, 2, {i + 1}, {}, edges_to_implied_weights_unconverted);
+                h.add_edge(i, i + 1, 2, {i + 1}, {});
             for (size_t i = 1; i < 7; i += 2)
-                h.add_edge(i, i + 1, -4, {i + 1}, {}, edges_to_implied_weights_unconverted);
-            h.add_boundary_edge(7, 2, {num_nodes}, {}, edges_to_implied_weights_unconverted);
+                h.add_edge(i, i + 1, -4, {i + 1}, {});
+            h.add_boundary_edge(7, 2, {num_nodes}, {});
         }
 
         mwpm.flooder.sync_negative_weight_observables_and_detection_events();
@@ -519,9 +510,8 @@ TEST(MwpmDecoding, NoValidSolutionForLineGraph) {
     size_t num_nodes = 5;
     auto mwpm = pm::Mwpm(pm::GraphFlooder(pm::MatchingGraph(num_nodes, num_nodes)));
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
     for (size_t i = 0; i < num_nodes; i++)
-        g.add_edge(i, (i + 1) % num_nodes, 2, {i}, {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, (i + 1) % num_nodes, 2, {i}, {});
     pm::ExtendedMatchingResult res(num_nodes);
     EXPECT_THROW(
         pm::decode_detection_events(mwpm, {0, 2, 3}, res.obs_crossed.data(), res.weight, /*enable_correlations=*/false);

--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -254,7 +254,6 @@ double pm::UserGraph::max_abs_weight() {
 
 pm::MatchingGraph pm::UserGraph::to_matching_graph(pm::weight_int num_distinct_weights) {
     pm::MatchingGraph matching_graph(nodes.size(), _num_observables);
-    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
 
     double normalising_constant = to_matching_or_search_graph_helper(
         num_distinct_weights,
@@ -263,15 +262,13 @@ pm::MatchingGraph pm::UserGraph::to_matching_graph(pm::weight_int num_distinct_w
             pm::signed_weight_int weight,
             const std::vector<size_t>& observables,
             const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
-            matching_graph.add_edge(
-                u, v, weight, observables, implied_weights_for_other_edges, edges_to_implied_weights_unconverted);
+            matching_graph.add_edge(u, v, weight, observables, implied_weights_for_other_edges);
         },
         [&](size_t u,
             pm::signed_weight_int weight,
             const std::vector<size_t>& observables,
             const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
-            matching_graph.add_boundary_edge(
-                u, weight, observables, implied_weights_for_other_edges, edges_to_implied_weights_unconverted);
+            matching_graph.add_boundary_edge(u, weight, observables, implied_weights_for_other_edges);
         });
 
     matching_graph.normalising_constant = normalising_constant;
@@ -282,14 +279,13 @@ pm::MatchingGraph pm::UserGraph::to_matching_graph(pm::weight_int num_distinct_w
             matching_graph.is_user_graph_boundary_node[i] = true;
     }
 
-    matching_graph.convert_implied_weights(edges_to_implied_weights_unconverted, normalising_constant);
+    matching_graph.convert_implied_weights(normalising_constant);
     return matching_graph;
 }
 
 pm::SearchGraph pm::UserGraph::to_search_graph(pm::weight_int num_distinct_weights) {
     /// Identical to to_matching_graph but for constructing a pm::SearchGraph
     pm::SearchGraph search_graph(nodes.size());
-    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
 
     double normalizing_constant = to_matching_or_search_graph_helper(
         num_distinct_weights,
@@ -298,18 +294,16 @@ pm::SearchGraph pm::UserGraph::to_search_graph(pm::weight_int num_distinct_weigh
             pm::signed_weight_int weight,
             const std::vector<size_t>& observables,
             const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
-            search_graph.add_edge(
-                u, v, weight, observables, implied_weights_for_other_edges, edges_to_implied_weights_unconverted);
+            search_graph.add_edge(u, v, weight, observables, implied_weights_for_other_edges);
         },
         [&](size_t u,
             pm::signed_weight_int weight,
             const std::vector<size_t>& observables,
             const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
-            search_graph.add_boundary_edge(
-                u, weight, observables, implied_weights_for_other_edges, edges_to_implied_weights_unconverted);
+            search_graph.add_boundary_edge(u, weight, observables, implied_weights_for_other_edges);
         });
 
-    search_graph.convert_implied_weights(edges_to_implied_weights_unconverted, normalizing_constant);
+    search_graph.convert_implied_weights(normalizing_constant);
     return search_graph;
 }
 

--- a/src/pymatching/sparse_blossom/flooder/graph.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph.cc
@@ -28,8 +28,7 @@ void MatchingGraph::add_edge(
     size_t v,
     signed_weight_int weight,
     const std::vector<size_t>& observables,
-    const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges,
-    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& all_edges_to_implied_weights_unconverted) {
+    const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
     size_t larger_node = std::max(u, v);
     if (larger_node + 1 > nodes.size()) {
         throw std::invalid_argument(
@@ -65,21 +64,20 @@ void MatchingGraph::add_edge(
     nodes[u].neighbor_weights.push_back(std::abs(weight));
     nodes[u].neighbor_observables.push_back(obs_mask);
     nodes[u].neighbor_implied_weights.push_back({});
-    all_edges_to_implied_weights_unconverted[u].emplace_back(implied_weights_for_other_edges);
+    edges_to_implied_weights_unconverted[u].emplace_back(implied_weights_for_other_edges);
 
     nodes[v].neighbors.push_back(&(nodes[u]));
     nodes[v].neighbor_weights.push_back(std::abs(weight));
     nodes[v].neighbor_observables.push_back(obs_mask);
     nodes[v].neighbor_implied_weights.push_back({});
-    all_edges_to_implied_weights_unconverted[v].emplace_back(implied_weights_for_other_edges);
+    edges_to_implied_weights_unconverted[v].emplace_back(implied_weights_for_other_edges);
 }
 
 void MatchingGraph::add_boundary_edge(
     size_t u,
     signed_weight_int weight,
     const std::vector<size_t>& observables,
-    const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges,
-    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& all_edges_to_implied_weights_unconverted) {
+    const std::vector<ImpliedWeightUnconverted>& implied_weights_for_other_edges) {
     if (u >= nodes.size()) {
         throw std::invalid_argument(
             "Node " + std::to_string(u) +
@@ -108,8 +106,8 @@ void MatchingGraph::add_boundary_edge(
     n.neighbor_weights.insert(n.neighbor_weights.begin(), 1, std::abs(weight));
     n.neighbor_observables.insert(n.neighbor_observables.begin(), 1, obs_mask);
     n.neighbor_implied_weights.insert(n.neighbor_implied_weights.begin(), 1, {});
-    all_edges_to_implied_weights_unconverted[u].insert(
-        all_edges_to_implied_weights_unconverted[u].begin(), 1, implied_weights_for_other_edges);
+    edges_to_implied_weights_unconverted[u].insert(
+        edges_to_implied_weights_unconverted[u].begin(), 1, implied_weights_for_other_edges);
 }
 
 MatchingGraph::MatchingGraph(size_t num_nodes, size_t num_observables)
@@ -181,9 +179,7 @@ ImpliedWeight convert_rule(
 
 }  // namespace
 
-void MatchingGraph::convert_implied_weights(
-    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted,
-    double normalising_constant) {
+void MatchingGraph::convert_implied_weights(double normalising_constant) {
     for (size_t u = 0; u < nodes.size(); u++) {
         const std::vector<std::vector<ImpliedWeightUnconverted>>& rules_for_node =
             edges_to_implied_weights_unconverted[u];

--- a/src/pymatching/sparse_blossom/flooder/graph.h
+++ b/src/pymatching/sparse_blossom/flooder/graph.h
@@ -68,12 +68,12 @@ class MatchingGraph {
         size_t v,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges);
+        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges = {});
     void add_boundary_edge(
         size_t u,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges);
+        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges = {});
     void update_negative_weight_observables(const std::vector<size_t>& observables);
     void update_negative_weight_detection_events(size_t node_id);
     void convert_implied_weights(double normalising_constant);

--- a/src/pymatching/sparse_blossom/flooder/graph.h
+++ b/src/pymatching/sparse_blossom/flooder/graph.h
@@ -57,6 +57,7 @@ class MatchingGraph {
     /// 16-bit ints.
     double normalising_constant;
     std::vector<PreviousWeight> previous_weights;
+    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
 
     MatchingGraph();
     MatchingGraph(size_t num_nodes, size_t num_observables);
@@ -67,19 +68,15 @@ class MatchingGraph {
         size_t v,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges,
-        std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted);
+        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges);
     void add_boundary_edge(
         size_t u,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges,
-        std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted);
+        const std::vector<pm::ImpliedWeightUnconverted>& implied_weights_for_other_edges);
     void update_negative_weight_observables(const std::vector<size_t>& observables);
     void update_negative_weight_detection_events(size_t node_id);
-    void convert_implied_weights(
-        std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted,
-        double normalising_constant);
+    void convert_implied_weights(double normalising_constant);
 
     std::unordered_map<const weight_int*, std::pair<int32_t, int32_t>> build_weight_location_map() const;
 

--- a/src/pymatching/sparse_blossom/flooder/graph.test.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph.test.cc
@@ -20,10 +20,9 @@
 
 TEST(Graph, AddEdge) {
     pm::MatchingGraph g(4, 64);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_edge(0, 1, -2, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, -3, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 3, 10, {1, 3}, {}, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, -2, {0}, {});
+    g.add_edge(1, 2, -3, {0, 2}, {});
+    g.add_edge(0, 3, 10, {1, 3}, {});
     ASSERT_EQ(g.nodes[0].neighbors[0], &g.nodes[1]);
     ASSERT_EQ(g.nodes[1].neighbors[0], &g.nodes[0]);
     ASSERT_EQ(g.nodes[3].neighbors[0], &g.nodes[0]);
@@ -40,10 +39,9 @@ TEST(Graph, AddEdge) {
 
 TEST(Graph, AddBoundaryEdge) {
     pm::MatchingGraph g(6, 64);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_edge(0, 1, 2, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(0, -7, {2}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(5, 10, {0, 1, 3}, {}, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, 2, {0, 1}, {});
+    g.add_boundary_edge(0, -7, {2}, {});
+    g.add_boundary_edge(5, 10, {0, 1, 3}, {});
     ASSERT_EQ(g.nodes[0].neighbors[0], nullptr);
     ASSERT_EQ(g.nodes[0].neighbor_weights[0], 7);
     ASSERT_EQ(g.nodes[0].neighbors[1], &g.nodes[1]);
@@ -56,40 +54,38 @@ TEST(Graph, AddBoundaryEdge) {
 
 TEST(Graph, AddEdgeWithImpliedWeights) {
     pm::MatchingGraph g(4, 64);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
     std::vector<pm::ImpliedWeightUnconverted> implied_weights = {{2, 3, 5}};
-    g.add_edge(0, 1, 10, {}, implied_weights, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, 10, {}, implied_weights);
 
-    ASSERT_EQ(edges_to_implied_weights_unconverted.size(), 2);
-    ASSERT_TRUE(edges_to_implied_weights_unconverted.count(0));
-    ASSERT_TRUE(edges_to_implied_weights_unconverted.count(1));
-    ASSERT_FALSE(edges_to_implied_weights_unconverted.count(2));
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted.size(), 2);
+    ASSERT_TRUE(g.edges_to_implied_weights_unconverted.count(0));
+    ASSERT_TRUE(g.edges_to_implied_weights_unconverted.count(1));
+    ASSERT_FALSE(g.edges_to_implied_weights_unconverted.count(2));
 
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].node1, 2);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].node2, 3);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].implied_weight, 5);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].node1, 2);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].node2, 3);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].implied_weight, 5);
 
-    ASSERT_EQ(edges_to_implied_weights_unconverted[1].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[1][0].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[1][0][0].node1, 2);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[1][0][0].node2, 3);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[1][0][0].implied_weight, 5);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[1].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[1][0].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[1][0][0].node1, 2);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[1][0][0].node2, 3);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[1][0][0].implied_weight, 5);
 }
 
 TEST(Graph, AddBoundaryEdgeWithImpliedWeights) {
     pm::MatchingGraph g(4, 64);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
     std::vector<pm::ImpliedWeightUnconverted> implied_weights = {{1, 2, 7}};
-    g.add_boundary_edge(0, 10, {}, implied_weights, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 10, {}, implied_weights);
 
-    ASSERT_EQ(edges_to_implied_weights_unconverted.size(), 1);
-    ASSERT_TRUE(edges_to_implied_weights_unconverted.count(0));
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted.size(), 1);
+    ASSERT_TRUE(g.edges_to_implied_weights_unconverted.count(0));
 
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0].size(), 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].node1, 1);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].node2, 2);
-    ASSERT_EQ(edges_to_implied_weights_unconverted[0][0][0].implied_weight, 7);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0].size(), 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].node1, 1);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].node2, 2);
+    ASSERT_EQ(g.edges_to_implied_weights_unconverted[0][0][0].implied_weight, 7);
 }

--- a/src/pymatching/sparse_blossom/flooder/graph_flooder.test.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph_flooder.test.cc
@@ -25,13 +25,12 @@ using namespace pm;
 TEST(GraphFlooder, PriorityQueue) {
     GraphFlooder flooder(MatchingGraph(10, 64));
     auto &graph = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    graph.add_edge(0, 1, 10, {}, {}, edges_to_implied_weights_unconverted);
-    graph.add_edge(1, 2, 10, {}, {}, edges_to_implied_weights_unconverted);
-    graph.add_edge(2, 3, 10, {}, {}, edges_to_implied_weights_unconverted);
-    graph.add_edge(3, 4, 10, {}, {}, edges_to_implied_weights_unconverted);
-    graph.add_edge(4, 5, 10, {}, {}, edges_to_implied_weights_unconverted);
-    graph.add_edge(5, 0, 10, {}, {}, edges_to_implied_weights_unconverted);
+    graph.add_edge(0, 1, 10, {}, {});
+    graph.add_edge(1, 2, 10, {}, {});
+    graph.add_edge(2, 3, 10, {}, {});
+    graph.add_edge(3, 4, 10, {}, {});
+    graph.add_edge(4, 5, 10, {}, {});
+    graph.add_edge(5, 0, 10, {}, {});
 
     auto qn = [&](int i, int t) {
         graph.nodes[i].node_event_tracker.set_desired_event({&graph.nodes[i], cyclic_time_int{t}}, flooder.queue);

--- a/src/pymatching/sparse_blossom/matcher/mwpm.test.cc
+++ b/src/pymatching/sparse_blossom/matcher/mwpm.test.cc
@@ -71,15 +71,14 @@ MwpmEvent rhr(std::vector<DetectorNode>& ns, size_t i, size_t j, obs_int obs_mas
 TEST(Mwpm, BlossomCreatedThenShattered) {
     auto mwpm = Mwpm(GraphFlooder(MatchingGraph(10, 64)));
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_edge(0, 1, 10, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 4, 20, {1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(4, 3, 20, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 2, 12, {2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 2, 16, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(4, 5, 50, {1, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 6, 100, {0, 1, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(5, 36, {3}, {}, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, 10, {0}, {});
+    g.add_edge(1, 4, 20, {1}, {});
+    g.add_edge(4, 3, 20, {0, 1}, {});
+    g.add_edge(3, 2, 12, {2}, {});
+    g.add_edge(0, 2, 16, {0, 2}, {});
+    g.add_edge(4, 5, 50, {1, 2}, {});
+    g.add_edge(2, 6, 100, {0, 1, 2}, {});
+    g.add_boundary_edge(5, 36, {3}, {});
     for (size_t i = 0; i < 7; i++) {
         mwpm.create_detection_event(&mwpm.flooder.graph.nodes[i]);
     }
@@ -278,9 +277,8 @@ TEST(Mwpm, ShatterBlossomAndExtractMatchesForPair) {
     size_t num_nodes = 20;
     auto mwpm = Mwpm(GraphFlooder(MatchingGraph(num_nodes, 64)));
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
     for (size_t i = 0; i < num_nodes - 1; i++)
-        g.add_edge(i, i + 1, 2, obs_mask_to_set_bits(i), {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, i + 1, 2, obs_mask_to_set_bits(i), {});
     auto& ns = mwpm.flooder.graph.nodes;
     mwpm.create_detection_event(&ns[6]);
     mwpm.create_detection_event(&ns[13]);
@@ -460,13 +458,12 @@ TEST(Mwpm, MatchingResult) {
 TEST(Mwpm, TwoRegionsGrowingThenMatching) {
     Mwpm mwpm(GraphFlooder(MatchingGraph(10, 64)));
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 4, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 100, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 22, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 30, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 4, 10, {0, 3}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(4, 1000, {1}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 4, {0, 1}, {});
+    g.add_edge(0, 1, 100, {0, 2}, {});
+    g.add_edge(1, 2, 22, {0, 2}, {});
+    g.add_edge(2, 3, 30, {0}, {});
+    g.add_edge(3, 4, 10, {0, 3}, {});
+    g.add_boundary_edge(4, 1000, {1}, {});
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[1]);
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[3]);
     auto e1 = mwpm.flooder.run_until_next_mwpm_notification();
@@ -490,15 +487,14 @@ TEST(Mwpm, TwoRegionsGrowingThenMatching) {
 TEST(Mwpm, RegionHittingMatchThenMatchedToOtherRegion) {
     Mwpm mwpm(GraphFlooder(MatchingGraph(10, 64)));
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 1000, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 8, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 10, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 2, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 4, 4, {0, 3}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(4, 5, 20, {1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(5, 6, 36, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(6, 1000, {1}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 1000, {0, 1}, {});
+    g.add_edge(0, 1, 8, {0, 2}, {});
+    g.add_edge(1, 2, 10, {0, 2}, {});
+    g.add_edge(2, 3, 2, {0}, {});
+    g.add_edge(3, 4, 4, {0, 3}, {});
+    g.add_edge(4, 5, 20, {1}, {});
+    g.add_edge(5, 6, 36, {0, 1}, {});
+    g.add_boundary_edge(6, 1000, {1}, {});
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[1]);
     auto r1 = mwpm.flooder.graph.nodes[1].region_that_arrived;
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[4]);
@@ -547,11 +543,10 @@ TEST(Mwpm, RegionHittingMatchFormingBlossomThenMatchingToBoundary) {
     size_t num_nodes = 100;
     Mwpm mwpm{GraphFlooder(MatchingGraph(num_nodes, 64))};
     auto& g = mwpm.flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2, {0}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2, {0}, {});
     for (size_t i = 0; i < num_nodes - 1; i++)
-        g.add_edge(i, i + 1, 2, obs_mask_to_set_bits(i), {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(num_nodes - 1, 2, {1}, {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, i + 1, 2, obs_mask_to_set_bits(i), {});
+    g.add_boundary_edge(num_nodes - 1, 2, {1}, {});
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[40]);
     auto r40 = mwpm.flooder.graph.nodes[40].region_that_arrived;
     mwpm.create_detection_event(&mwpm.flooder.graph.nodes[42]);
@@ -585,12 +580,11 @@ TEST(GraphFlooder, CreateRegion) {
     Mwpm mwpm{GraphFlooder(MatchingGraph(5, 64))};
     auto& flooder = mwpm.flooder;
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 3, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 5, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 11, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 100, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(3, 1000, {}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 3, {}, {});
+    g.add_edge(0, 1, 5, {}, {});
+    g.add_edge(1, 2, 11, {}, {});
+    g.add_edge(2, 3, 100, {}, {});
+    g.add_boundary_edge(3, 1000, {}, {});
     mwpm.create_detection_event(&flooder.graph.nodes[0]);
     mwpm.create_detection_event(&flooder.graph.nodes[2]);
     mwpm.create_detection_event(&flooder.graph.nodes[3]);
@@ -607,13 +601,12 @@ TEST(GraphFlooder, RegionGrowingToBoundary) {
     Mwpm mwpm{GraphFlooder(MatchingGraph(10, 64))};
     auto& flooder = mwpm.flooder;
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 10, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 21, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 100, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 4, 7, {0, 3}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(4, 5, {1}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2, {0, 1}, {});
+    g.add_edge(0, 1, 10, {0, 2}, {});
+    g.add_edge(1, 2, 21, {}, {});
+    g.add_edge(2, 3, 100, {0}, {});
+    g.add_edge(3, 4, 7, {0, 3}, {});
+    g.add_boundary_edge(4, 5, {1}, {});
     mwpm.create_detection_event(&flooder.graph.nodes[2]);
     ASSERT_EQ(
         flooder.run_until_next_mwpm_notification(),
@@ -642,13 +635,12 @@ TEST(GraphFlooder, RegionHitRegion) {
     Mwpm mwpm{GraphFlooder(MatchingGraph(10, 64))};
     auto& flooder = mwpm.flooder;
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2000, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 10, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 24, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 38, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 4, 26, {0, 3}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(4, 1000, {1}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2000, {0, 1}, {});
+    g.add_edge(0, 1, 10, {0, 2}, {});
+    g.add_edge(1, 2, 24, {}, {});
+    g.add_edge(2, 3, 38, {0}, {});
+    g.add_edge(3, 4, 26, {0, 3}, {});
+    g.add_boundary_edge(4, 1000, {1}, {});
     mwpm.create_detection_event(&flooder.graph.nodes[2]);
     mwpm.create_detection_event(&flooder.graph.nodes[4]);
     auto e1 = flooder.run_until_next_mwpm_notification();
@@ -664,13 +656,12 @@ TEST(GraphFlooder, RegionGrowingThenFrozenThenStartShrinking) {
     Mwpm mwpm{GraphFlooder(MatchingGraph(10, 64))};
     auto& flooder = mwpm.flooder;
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 4, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 1, 10, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 22, {}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(2, 3, 30, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(3, 4, 50, {0, 3}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(4, 100, {1}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 4, {0, 1}, {});
+    g.add_edge(0, 1, 10, {0, 2}, {});
+    g.add_edge(1, 2, 22, {}, {});
+    g.add_edge(2, 3, 30, {0}, {});
+    g.add_edge(3, 4, 50, {0, 3}, {});
+    g.add_boundary_edge(4, 100, {1}, {});
     mwpm.create_detection_event(&flooder.graph.nodes[2]);
     auto e1 = flooder.run_until_next_mwpm_notification();
     ASSERT_EQ(

--- a/src/pymatching/sparse_blossom/search/search_flooder.test.cc
+++ b/src/pymatching/sparse_blossom/search/search_flooder.test.cc
@@ -20,10 +20,9 @@ TEST(SearchFlooder, RepCodeDetectorSearch) {
     size_t num_nodes = 40;
     auto flooder = pm::SearchFlooder(pm::SearchGraph(num_nodes));
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2, {0}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2, {0}, {});
     for (size_t i = 0; i < num_nodes - 1; i++)
-        g.add_edge(i, i + 1, 2, {i + 1}, {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, i + 1, 2, {i + 1}, {});
 
     auto collision_edge = flooder.run_until_collision(&g.nodes[1], &g.nodes[20]);
     ASSERT_EQ(collision_edge.detector_node, &g.nodes[11]);
@@ -59,10 +58,9 @@ TEST(SearchFlooder, RepCodeBoundarySearch) {
     size_t num_nodes = 20;
     auto flooder = pm::SearchFlooder(pm::SearchGraph(num_nodes));
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2, {0}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2, {0}, {});
     for (size_t i = 0; i < num_nodes - 1; i++)
-        g.add_edge(i, i + 1, 2, {i + 1}, {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, i + 1, 2, {i + 1}, {});
 
     auto collision_edge = flooder.run_until_collision(&g.nodes[6], nullptr);
     ASSERT_EQ(collision_edge.detector_node, &g.nodes[0]);
@@ -88,10 +86,9 @@ TEST(SearchFlooder, RepCodeSourceToDestPath) {
     size_t num_nodes = 20;
     auto flooder = pm::SearchFlooder(pm::SearchGraph(num_nodes));
     auto& g = flooder.graph;
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_boundary_edge(0, 2, {0}, {}, edges_to_implied_weights_unconverted);
+    g.add_boundary_edge(0, 2, {0}, {});
     for (size_t i = 0; i < num_nodes - 1; i++)
-        g.add_edge(i, i + 1, 2, {i + 1}, {}, edges_to_implied_weights_unconverted);
+        g.add_edge(i, i + 1, 2, {i + 1}, {});
     size_t i_start = 10;
     for (size_t i_end = 14; i_end < 18; i_end++) {
         std::vector<pm::SearchGraphEdge> edges;

--- a/src/pymatching/sparse_blossom/search/search_graph.h
+++ b/src/pymatching/sparse_blossom/search/search_graph.h
@@ -36,6 +36,7 @@ class SearchGraph {
 
     // Used to restore weights after reweighting.
     std::vector<PreviousWeight> previous_weights;
+    std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
 
     SearchGraph();
     explicit SearchGraph(size_t num_nodes);
@@ -45,17 +46,13 @@ class SearchGraph {
         size_t v,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<ImpliedWeightUnconverted>& implied_weights,
-        std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted);
+        const std::vector<ImpliedWeightUnconverted>& implied_weights);
     void add_boundary_edge(
         size_t u,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<ImpliedWeightUnconverted>& implied_weights,
-        std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted);
-    void convert_implied_weights(
-        std::map<size_t, std::vector<std::vector<ImpliedWeightUnconverted>>>& edges_to_implied_weights_unconverted,
-        const double normalizing_constant);
+        const std::vector<ImpliedWeightUnconverted>& implied_weights);
+    void convert_implied_weights(const double normalizing_constant);
     void reweight(std::vector<ImpliedWeight>& implied_weights);
     void reweight_for_edge(const int64_t& u, const int64_t& v);
     void reweight_for_edges(const std::vector<int64_t>& edges);

--- a/src/pymatching/sparse_blossom/search/search_graph.h
+++ b/src/pymatching/sparse_blossom/search/search_graph.h
@@ -46,12 +46,12 @@ class SearchGraph {
         size_t v,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<ImpliedWeightUnconverted>& implied_weights);
+        const std::vector<ImpliedWeightUnconverted>& implied_weights = {});
     void add_boundary_edge(
         size_t u,
         signed_weight_int weight,
         const std::vector<size_t>& observables,
-        const std::vector<ImpliedWeightUnconverted>& implied_weights);
+        const std::vector<ImpliedWeightUnconverted>& implied_weights = {});
     void convert_implied_weights(const double normalizing_constant);
     void reweight(std::vector<ImpliedWeight>& implied_weights);
     void reweight_for_edge(const int64_t& u, const int64_t& v);

--- a/src/pymatching/sparse_blossom/search/search_graph.test.cc
+++ b/src/pymatching/sparse_blossom/search/search_graph.test.cc
@@ -19,10 +19,9 @@
 
 TEST(SearchGraph, AddEdge) {
     pm::SearchGraph g(4);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_edge(0, 1, 2, {0}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(1, 2, 3, {0, 2}, {}, edges_to_implied_weights_unconverted);
-    g.add_edge(0, 3, 10, {1, 3}, {}, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, 2, {0}, {});
+    g.add_edge(1, 2, 3, {0, 2}, {});
+    g.add_edge(0, 3, 10, {1, 3}, {});
     ASSERT_EQ(g.nodes[0].neighbors[0], &g.nodes[1]);
     ASSERT_EQ(g.nodes[1].neighbors[0], &g.nodes[0]);
     ASSERT_EQ(g.nodes[3].neighbors[0], &g.nodes[0]);
@@ -37,10 +36,9 @@ TEST(SearchGraph, AddEdge) {
 
 TEST(SearchGraph, AddBoundaryEdge) {
     pm::SearchGraph g(6);
-    std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
-    g.add_edge(0, 1, 2, {0, 1}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(0, 7, {2}, {}, edges_to_implied_weights_unconverted);
-    g.add_boundary_edge(5, 10, {0, 1, 3}, {}, edges_to_implied_weights_unconverted);
+    g.add_edge(0, 1, 2, {0, 1}, {});
+    g.add_boundary_edge(0, 7, {2}, {});
+    g.add_boundary_edge(5, 10, {0, 1, 3}, {});
     ASSERT_EQ(g.nodes[0].neighbors[0], nullptr);
     ASSERT_EQ(g.nodes[0].neighbors[1], &g.nodes[1]);
     ASSERT_EQ(g.nodes[5].neighbors[0], nullptr);


### PR DESCRIPTION
Fixes https://github.com/oscarhiggott/PyMatching/issues/145 and https://github.com/oscarhiggott/PyMatching/issues/150