### PR TITLE
Check for invalid pymatching.Matching configuration when decoding with enable_correlations=True

### DIFF
--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -111,7 +111,7 @@ class Matching:
             (row) of `check_matrix` is set to `measurement_error_probabilities[i]`. By default None
         enable_correlations : bool, optional
             If `enable_correlations==True`, and if `graph` is a `stim.Circuit` or `stim.DetectorErrorModel`,
-            the circuit or detector error model is converted into an internal representation that allows 
+            the circuit or detector error model is converted into an internal representation that allows
             correlated matching to be used. Note that you must set `enable_correlations=True` here in order
             to use `enable_correlations=True` when decoding. By default, False.
         **kwargs
@@ -1249,7 +1249,7 @@ class Matching:
             error mechanisms
         enable_correlations : bool, optional
             If `enable_correlations==True`, the detector error model is converted into an internal
-            representation that allows correlated matching to be used. Note that you must set 
+            representation that allows correlated matching to be used. Note that you must set
             `enable_correlations=True` here in order to use `enable_correlations=True` when decoding.
             By default, False.
 
@@ -1309,7 +1309,7 @@ class Matching:
             graphlike error mechanisms
         enable_correlations : bool, optional
             If `enable_correlations==True`, the circuit's detector error model is converted into an internal
-            representation that allows correlated matching to be used. Note that you must set 
+            representation that allows correlated matching to be used. Note that you must set
             `enable_correlations=True` here in order to use `enable_correlations=True` when decoding.
             By default, False.
 

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -241,7 +241,7 @@ class Matching:
             If `return_weight==True`, the sum of the weights of the edges in the
             minimum weight perfect matching is also returned. By default False
             If True, then also return the weight of the solution. The weight of the
-            solution is the sum of the weight of its edges. 
+            solution is the sum of the weight of its edges.
             If `enable_correlations==True` as well, then the solution weight uses
             the modified edge weights (i.e. the edge weights after they have been
             changed by the correlated matching algorithm). By default, False.
@@ -407,7 +407,7 @@ class Matching:
             hyperedge error is a Y error in the surface code. To use correlated matching,
             the `pymatching.Matching` object must be configured from a `stim.Circuit` or
             `stim.DetectorErrorModel` with `enable_correlations=True`. For a description
-            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863. 
+            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863.
             By default, False
 
         Returns
@@ -500,7 +500,7 @@ class Matching:
             hyperedge error is a Y error in the surface code. To use correlated matching,
             the `pymatching.Matching` object must be configured from a `stim.Circuit` or
             `stim.DetectorErrorModel` with `enable_correlations=True`. For a description
-            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863. 
+            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863.
             By default, False
 
         Returns

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -240,9 +240,22 @@ class Matching:
         return_weight : bool, optional
             If `return_weight==True`, the sum of the weights of the edges in the
             minimum weight perfect matching is also returned. By default False
+            If True, then also return the weight of the solution. The weight of the
+            solution is the sum of the weight of its edges. 
+            If `enable_correlations==True` as well, then the solution weight uses
+            the modified edge weights (i.e. the edge weights after they have been
+            changed by the correlated matching algorithm). By default, False.
         enable_correlations: bool, optional
             If `enable_correlations==True`, two-pass correlated matching is used
-            for decoding (see https://arxiv.org/abs/1310.0863).
+            for decoding. Correlated matching is a more accurate variant of matching
+            that exploits knowledge of any hyperedge error (errors that flip more
+            than two detectors), provided that these errors can be decomposed into
+            edges (errors that flip one or two detectors). An example of a decomposable
+            hyperedge error is a Y error in the surface code. To use correlated matching,
+            the `pymatching.Matching` object must be configured from a `stim.Circuit` or
+            `stim.DetectorErrorModel` with `enable_correlations=True`. For a description
+            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863.
+            By default, False
 
         Returns
         -------
@@ -376,13 +389,26 @@ class Matching:
             detection event `m` in shot `s` can be found at ``(dets[s, m // 8] >> (m % 8)) & 1``.
         return_weights : bool
             If True, then also return a numpy array containing the weights of the solutions for all the shots.
-            By default, False.
+            The weight of a solution is the sum of the weight of its edges. If `enable_correlations==True` as
+            well, then the solution weight uses the modified edge weights (i.e. the edge weights after they
+            have been changed by the correlated matching algorithm). By default, False.
         bit_packed_shots : bool
             Set to `True` to provide `shots` as a bit-packed array, such that the bit for
             detection event `m` in shot `s` can be found at ``(dets[s, m // 8] >> (m % 8)) & 1``.
         bit_packed_predictions : bool
             Set to `True` if the returned predictions should be bit-packed, with the bit for fault id `m` in
             shot `s` in ``(obs[s, m // 8] >> (m % 8)) & 1``
+        enable_correlations: bool, optional
+            If `enable_correlations==True`, two-pass correlated matching is used
+            for decoding. Correlated matching is a more accurate variant of matching
+            that exploits knowledge of any hyperedge error (errors that flip more
+            than two detectors), provided that these errors can be decomposed into
+            edges (errors that flip one or two detectors). An example of a decomposable
+            hyperedge error is a Y error in the surface code. To use correlated matching,
+            the `pymatching.Matching` object must be configured from a `stim.Circuit` or
+            `stim.DetectorErrorModel` with `enable_correlations=True`. For a description
+            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863. 
+            By default, False
 
         Returns
         -------
@@ -465,10 +491,17 @@ class Matching:
             (modulo 2) between the (noisy) measurement of stabiliser `i` in time
             step `j+1` and time step `j` (for the case where the matching graph is
             constructed from a check matrix with `repetitions>1`).
-        enable_correlations : bool, optional
-            Whether to use correlated matching (https://arxiv.org/abs/1310.0863).
-            This can result in a more accurate solution, but may be slower.
-            Defaults to False.
+        enable_correlations: bool, optional
+            If `enable_correlations==True`, two-pass correlated matching is used
+            for decoding. Correlated matching is a more accurate variant of matching
+            that exploits knowledge of any hyperedge error (errors that flip more
+            than two detectors), provided that these errors can be decomposed into
+            edges (errors that flip one or two detectors). An example of a decomposable
+            hyperedge error is a Y error in the surface code. To use correlated matching,
+            the `pymatching.Matching` object must be configured from a `stim.Circuit` or
+            `stim.DetectorErrorModel` with `enable_correlations=True`. For a description
+            of the correlated matching algorithm, see https://arxiv.org/abs/1310.0863. 
+            By default, False
 
         Returns
         -------

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -46,13 +46,15 @@ class Matching:
                  repetitions: int = None,
                  timelike_weights: Union[float, np.ndarray, List[float]] = None,
                  measurement_error_probabilities: Union[float, np.ndarray, List[float]] = None,
+                 *,
+                 enable_correlations: bool = False,
                  **kwargs
                  ):
         r"""Constructor for the Matching class
 
         Parameters
         ----------
-        graph : `scipy.spmatrix` or `numpy.ndarray` or `networkx.Graph` or `stim.DetectorErrorModel`, optional
+        graph : `scipy.spmatrix` or `numpy.ndarray` or `networkx.Graph` or `stim.DetectorErrorModel`, or `stim.Circuit`, optional
             The matching graph to be decoded with minimum-weight perfect
             matching, given either as a binary parity check matrix (scipy sparse
             matrix or numpy.ndarray), a NetworkX or rustworkx graph, or a Stim DetectorErrorModel.
@@ -107,6 +109,11 @@ class Matching:
             errors are set to the same value. If a numpy array of size `(check_matrix.shape[0],)` is given,
             the error probability for each vertical timelike edge associated with the `i`th check
             (row) of `check_matrix` is set to `measurement_error_probabilities[i]`. By default None
+        enable_correlations : bool, optional
+            If `enable_correlations==True`, and if `graph` is a `stim.Circuit` or `stim.DetectorErrorModel`,
+            the circuit or detector error model is converted into an internal representation that allows 
+            correlated matching to be used. Note that you must set `enable_correlations=True` here in order
+            to use `enable_correlations=True` when decoding. By default, False.
         **kwargs
             The remaining keyword arguments are passed to `Matching.load_from_check_matrix` if `graph` is a
             check matrix.
@@ -153,7 +160,11 @@ class Matching:
         try:
             import stim
             if isinstance(graph, stim.DetectorErrorModel):
-                self._load_from_detector_error_model(graph)
+                self._load_from_detector_error_model(graph, enable_correlations=enable_correlations)
+                return
+            elif isinstance(graph, stim.Circuit):
+                self.from_stim_circuit
+                self._load_from_detector_error_model(graph.detector_error_model(decompose_errors=True), enable_correlations=enable_correlations)
                 return
         except ImportError:  # pragma no cover
             pass
@@ -229,6 +240,9 @@ class Matching:
         return_weight : bool, optional
             If `return_weight==True`, the sum of the weights of the edges in the
             minimum weight perfect matching is also returned. By default False
+        enable_correlations: bool, optional
+            If `enable_correlations==True`, two-pass correlated matching is used
+            for decoding (see https://arxiv.org/abs/1310.0863).
 
         Returns
         -------
@@ -628,8 +642,8 @@ class Matching:
                "{} detector{}, " \
                "{} boundary node{}, " \
                "and {} edge{}>".format(
-                m, 's' if m != 1 else '', b, 's' if b != 1 else '',
-                e, 's' if e != 1 else '')
+                   m, 's' if m != 1 else '', b, 's' if b != 1 else '',
+                   e, 's' if e != 1 else '')
 
     def add_edge(
             self,
@@ -1233,6 +1247,11 @@ class Matching:
         model : stim.DetectorErrorModel
             A stim DetectorErrorModel, with all error mechanisms either graphlike, or decomposed into graphlike
             error mechanisms
+        enable_correlations : bool, optional
+            If `enable_correlations==True`, the detector error model is converted into an internal
+            representation that allows correlated matching to be used. Note that you must set 
+            `enable_correlations=True` here in order to use `enable_correlations=True` when decoding.
+            By default, False.
 
         Returns
         -------
@@ -1279,7 +1298,7 @@ class Matching:
         return m
 
     @staticmethod
-    def from_stim_circuit(circuit: 'stim.Circuit') -> 'pymatching.Matching':
+    def from_stim_circuit(circuit: 'stim.Circuit', *, enable_correlations=False) -> 'pymatching.Matching':
         """
         Constructs a `pymatching.Matching` object by loading from a `stim.Circuit`
 
@@ -1288,6 +1307,11 @@ class Matching:
         circuit : stim.Circuit
             A stim circuit containing error mechanisms that are all either graphlike, or decomposable into
             graphlike error mechanisms
+        enable_correlations : bool, optional
+            If `enable_correlations==True`, the circuit's detector error model is converted into an internal
+            representation that allows correlated matching to be used. Note that you must set 
+            `enable_correlations=True` here in order to use `enable_correlations=True` when decoding.
+            By default, False.
 
         Returns
         -------
@@ -1321,7 +1345,8 @@ class Matching:
             raise TypeError(f"`circuit` must be a `stim.Circuit`. Instead, got {type(circuit)}")
         m = Matching()
         m._matching_graph = _cpp_pm.detector_error_model_to_matching_graph(
-            str(circuit.detector_error_model(decompose_errors=True))
+            str(circuit.detector_error_model(decompose_errors=True)),
+            enable_correlations=enable_correlations
         )
         return m
 

--- a/src/pymatching/sparse_blossom/driver/mwpm_decoding.perf.cc
+++ b/src/pymatching/sparse_blossom/driver/mwpm_decoding.perf.cc
@@ -19,7 +19,7 @@
 #include "stim.h"
 
 std::pair<stim::DetectorErrorModel, std::vector<stim::SparseShot>> generate_data(
-    size_t distance, size_t rounds, double noise, size_t num_shots) {
+    size_t distance, size_t rounds, double noise, size_t num_shots, bool decompose_errors = false) {
     stim::CircuitGenParameters gen(rounds, distance, "rotated_memory_x");
     gen.after_clifford_depolarization = noise;
     gen.after_reset_flip_probability = noise;
@@ -42,7 +42,8 @@ std::pair<stim::DetectorErrorModel, std::vector<stim::SparseShot>> generate_data
         }
     }
 
-    auto dem = stim::ErrorAnalyzer::circuit_to_detector_error_model(circuit, false, true, false, 0, false, false);
+    auto dem =
+        stim::ErrorAnalyzer::circuit_to_detector_error_model(circuit, decompose_errors, true, false, 0, false, false);
 
     return {dem, shots};
 }
@@ -310,7 +311,7 @@ BENCHMARK(Decode_surface_r21_d21_p100_to_edges) {
 
 BENCHMARK(Decode_surface_r21_d21_p100_to_edges_with_correlations) {
     size_t rounds = 21;
-    auto data = generate_data(21, rounds, 0.01, 8);
+    auto data = generate_data(21, rounds, 0.01, 8, true);
     auto &dem = data.first;
     const auto &shots = data.second;
 
@@ -434,7 +435,7 @@ BENCHMARK(Decode_surface_r21_d21_p1000_to_edges) {
 
 BENCHMARK(Decode_surface_r21_d21_p1000_to_edges_with_correlations) {
     size_t rounds = 21;
-    auto data = generate_data(21, rounds, 0.001, 256);
+    auto data = generate_data(21, rounds, 0.001, 256, true);
     auto &dem = data.first;
     const auto &shots = data.second;
 
@@ -558,7 +559,7 @@ BENCHMARK(Decode_surface_r21_d21_p10000_to_edges) {
 
 BENCHMARK(Decode_surface_r21_d21_p10000_to_edges_with_correlations) {
     size_t rounds = 21;
-    auto data = generate_data(21, rounds, 0.0001, 512);
+    auto data = generate_data(21, rounds, 0.0001, 512, true);
     auto &dem = data.first;
     const auto &shots = data.second;
 
@@ -682,7 +683,7 @@ BENCHMARK(Decode_surface_r21_d21_p100000_to_edges) {
 
 BENCHMARK(Decode_surface_r21_d21_p100000_to_edges_with_correlations) {
     size_t rounds = 21;
-    auto data = generate_data(21, rounds, 0.00001, 512);
+    auto data = generate_data(21, rounds, 0.00001, 512, true);
     auto &dem = data.first;
     const auto &shots = data.second;
 

--- a/src/pymatching/sparse_blossom/driver/user_graph.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.cc
@@ -313,10 +313,12 @@ pm::Mwpm pm::UserGraph::to_mwpm(pm::weight_int num_distinct_weights, bool ensure
             pm::GraphFlooder(to_matching_graph(num_distinct_weights)),
             pm::SearchFlooder(to_search_graph(num_distinct_weights)));
         mwpm.flooder.sync_negative_weight_observables_and_detection_events();
+        mwpm.flooder.graph.loaded_from_dem_without_correlations = loaded_from_dem_without_correlations;
         return mwpm;
     } else {
         auto mwpm = pm::Mwpm(pm::GraphFlooder(to_matching_graph(num_distinct_weights)));
         mwpm.flooder.sync_negative_weight_observables_and_detection_events();
+        mwpm.flooder.graph.loaded_from_dem_without_correlations = loaded_from_dem_without_correlations;
         return mwpm;
     }
 }
@@ -499,6 +501,7 @@ pm::UserGraph pm::detector_error_model_to_user_graph(
             [&](double p, const std::vector<size_t>& detectors, std::vector<size_t>& observables) {
                 user_graph.handle_dem_instruction(p, detectors, observables);
             });
+        user_graph.loaded_from_dem_without_correlations = true;
     }
     return user_graph;
 }

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -63,6 +63,7 @@ class UserGraph {
     std::vector<UserNode> nodes;
     std::list<UserEdge> edges;
     std::set<size_t> boundary_nodes;
+    bool loaded_from_dem_without_correlations = false;
 
     UserGraph();
     explicit UserGraph(size_t num_nodes);
@@ -298,9 +299,12 @@ void iter_dem_instructions_include_correlations(
                         component->node1 = target.raw_id();
                     }
                 } else {
-                    // We mark errors which have 3 or more detectors as a special boundary-to-boundary edge.
-                    component->node1 = SIZE_MAX;
-                    component->node2 = SIZE_MAX;
+                    // Undecomposed hyperedges are not supported
+                    throw std::invalid_argument(
+                        "Encountered an undecomposed error instruction with 3 or mode detectors. "
+                        "This is not supported when using `enable_correlations=True`. "
+                        "Did you forget to set `decompose_errors=True` when "
+                        "using `stim.Circuit.detector_error_model(decompose_error=True)`?");
                 }
             } else if (target.is_observable_id()) {
                 component->observable_indices.push_back(target.val());

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -304,7 +304,7 @@ void iter_dem_instructions_include_correlations(
                         "Encountered an undecomposed error instruction with 3 or mode detectors. "
                         "This is not supported when using `enable_correlations=True`. "
                         "Did you forget to set `decompose_errors=True` when "
-                        "using `stim.Circuit.detector_error_model(decompose_error=True)`?");
+                        "converting the stim circuit to a detector error model?");
                 }
             } else if (target.is_observable_id()) {
                 component->observable_indices.push_back(target.val());

--- a/src/pymatching/sparse_blossom/driver/user_graph.perf.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.perf.cc
@@ -15,14 +15,14 @@
 #include "mwpm_decoding.h"
 #include "pymatching/perf/util.perf.h"
 
-stim::DetectorErrorModel generate_dem(size_t distance, size_t rounds, double noise) {
+stim::DetectorErrorModel generate_dem(size_t distance, size_t rounds, double noise, bool decompose_errors = false) {
     stim::CircuitGenParameters gen(rounds, distance, "rotated_memory_x");
     gen.after_clifford_depolarization = noise;
     gen.after_reset_flip_probability = noise;
     gen.before_measure_flip_probability = noise;
     stim::Circuit circuit = stim::generate_surface_code_circuit(gen).circuit;
     std::mt19937_64 rng(0);  // NOLINT(cert-msc51-cpp)
-    auto dem = stim::ErrorAnalyzer::circuit_to_detector_error_model(circuit, false, true, false, 0, false, false);
+    auto dem = stim::ErrorAnalyzer::circuit_to_detector_error_model(circuit, decompose_errors, true, false, 0, false, false);
     return dem;
 }
 
@@ -53,7 +53,7 @@ BENCHMARK(Load_dem_r21_d21_p100) {
 }
 
 BENCHMARK(Load_dem_r11_d11_p100_correlations) {
-    auto dem = generate_dem(11, 11, 0.01);
+    auto dem = generate_dem(11, 11, 0.01, true);
     size_t num_buckets = 1024;
     size_t num_loads = 10;
     benchmark_go([&]() {
@@ -67,7 +67,7 @@ BENCHMARK(Load_dem_r11_d11_p100_correlations) {
 }
 
 BENCHMARK(Load_dem_r21_d21_p100_correlations) {
-    auto dem = generate_dem(21, 21, 0.01);
+    auto dem = generate_dem(21, 21, 0.01, true);
     size_t num_buckets = 1024;
     size_t num_loads = 10;
     benchmark_go([&]() {

--- a/src/pymatching/sparse_blossom/driver/user_graph.test.cc
+++ b/src/pymatching/sparse_blossom/driver/user_graph.test.cc
@@ -304,13 +304,11 @@ TEST(IterDemInstructionsTest, ZeroProbabilityError) {
     ASSERT_TRUE(joint_probabilities.empty());
 }
 
-TEST(IterDemInstructionsTest, ThreeDetectorErrorIsIgnored) {
+TEST(IterDemInstructionsTest, ThreeDetectorErrorThrowsInvalidArgument) {
     stim::DetectorErrorModel dem("error(0.1) D0 D1 D2");
     TestHandler handler;
     std::map<std::pair<size_t, size_t>, std::map<std::pair<size_t, size_t>, double>> joint_probabilities;
-    pm::iter_dem_instructions_include_correlations(dem, handler, joint_probabilities);
-    ASSERT_TRUE(handler.handled_errors.empty());
-    ASSERT_TRUE(joint_probabilities.empty());
+    ASSERT_THROW(pm::iter_dem_instructions_include_correlations(dem, handler, joint_probabilities), std::invalid_argument);
 }
 
 // Test a decomposed error instruction. The handler should be called for each component.
@@ -360,7 +358,6 @@ TEST(IterDemInstructionsTest, CombinedComplexDem) {
     stim::DetectorErrorModel dem(R"DEM(
         error(0.1) D0            # Instruction 1: Simple
         error(0.2) D1 D2 L0      # Instruction 2: Two detectors, one observable
-        error(0.3) D3 D4 D5      # Instruction 3: Hyperedge ignored, second component handled
         error(0.0) D7            # Instruction 4: Zero probability, ignored
         error(0.4) D8 ^ D9 L1    # Instruction 5: Decomposed
     )DEM");

--- a/src/pymatching/sparse_blossom/flooder/graph.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph.cc
@@ -131,7 +131,10 @@ MatchingGraph::MatchingGraph(MatchingGraph&& graph) noexcept
       is_user_graph_boundary_node(std::move(graph.is_user_graph_boundary_node)),
       num_nodes(graph.num_nodes),
       num_observables(graph.num_observables),
-      normalising_constant(graph.normalising_constant) {
+      normalising_constant(graph.normalising_constant),
+      previous_weights(graph.previous_weights),
+      edges_to_implied_weights_unconverted(graph.edges_to_implied_weights_unconverted),
+      loaded_from_dem_without_correlations(graph.loaded_from_dem_without_correlations) {
 }
 
 MatchingGraph::MatchingGraph() : negative_weight_sum(0), num_nodes(0), num_observables(0), normalising_constant(0) {
@@ -200,6 +203,13 @@ void MatchingGraph::reweight_for_edge(const int64_t& u, const int64_t& v) {
 }
 
 void MatchingGraph::reweight_for_edges(const std::vector<int64_t>& edges) {
+    if (loaded_from_dem_without_correlations) {
+        throw std::invalid_argument(
+            "Attempting to decode with `enable_correlations=True`, however the decoder has "
+            "not been configured to decode using correlations. Ensure that you also set "
+            "`enable_correlations=True` when loading the stim circuit or detector error model. "
+            "For example: `matching = pymatching.Matching.from_detector_error_model(enable_correlations=True)`");
+    }
     for (size_t i = 0; i < edges.size() >> 1; ++i) {
         int64_t u = edges[2 * i];
         int64_t v = edges[2 * i + 1];

--- a/src/pymatching/sparse_blossom/flooder/graph.cc
+++ b/src/pymatching/sparse_blossom/flooder/graph.cc
@@ -208,7 +208,7 @@ void MatchingGraph::reweight_for_edges(const std::vector<int64_t>& edges) {
             "Attempting to decode with `enable_correlations=True`, however the decoder has "
             "not been configured to decode using correlations. Ensure that you also set "
             "`enable_correlations=True` when loading the stim circuit or detector error model. "
-            "For example: `matching = pymatching.Matching.from_detector_error_model(enable_correlations=True)`");
+            "For example: `matching = pymatching.Matching.from_detector_error_model(dem, enable_correlations=True)`");
     }
     for (size_t i = 0; i < edges.size() >> 1; ++i) {
         int64_t u = edges[2 * i];

--- a/src/pymatching/sparse_blossom/flooder/graph.h
+++ b/src/pymatching/sparse_blossom/flooder/graph.h
@@ -58,6 +58,10 @@ class MatchingGraph {
     double normalising_constant;
     std::vector<PreviousWeight> previous_weights;
     std::map<size_t, std::vector<std::vector<pm::ImpliedWeightUnconverted>>> edges_to_implied_weights_unconverted;
+    // Tracks whether the MatchingGraph was loaded from a DEM without enable_correlations. This is used to
+    // alert a user if they try to decode with enable_correlations=true, but forgot to load from the
+    // dem with enable_correlations=true.
+    bool loaded_from_dem_without_correlations = false;
 
     MatchingGraph();
     MatchingGraph(size_t num_nodes, size_t num_observables);


### PR DESCRIPTION
Checks that the user has set enable_correlations=True when loading from a stim circuit or dem if the user decodes with enable_correlations=True

Also checks that the user has set decompose_errors=True when generating a dem when they try to load with enable_correlations=True

In both cases a ValueError is raised.

Tests added to check for the ValueError.