### PR TITLE
Fix typos, API issues, and bugs related to correlated matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ print(num_errors)  # prints 8
 
 To decode instead with correlated matching, set `enable_correlations=True` both when configuiing the `pymatching.Matching` object:
 ```python
-matching_corr = pymatching.Matching.from_detector_error_model(dem, enable_correlations=True)
+matching_corr = pymatching.Matching.from_detector_error_model(model, enable_correlations=True)
 ```
 
 as well as when decoding:

--- a/src/pymatching/matching.py
+++ b/src/pymatching/matching.py
@@ -1296,7 +1296,9 @@ class Matching:
         return m
 
     @staticmethod
-    def from_detector_error_model_file(dem_path: Union[str, Path]) -> 'pymatching.Matching':
+    def from_detector_error_model_file(
+            dem_path: Union[str, Path], *, enable_correlations: bool = False
+    ) -> 'pymatching.Matching':
         """
         Construct a `pymatching.Matching` by loading from a stim DetectorErrorModel file path.
 
@@ -1304,6 +1306,11 @@ class Matching:
         ----------
         dem_path : str
             The path of the detector error model file
+        enable_correlations : bool, optional
+            If `enable_correlations==True`, the detector error model is converted into an internal
+            representation that allows correlated matching to be used. Note that you must set
+            `enable_correlations=True` here in order to use `enable_correlations=True` when decoding.
+            By default, False.
 
         Returns
         -------
@@ -1314,7 +1321,7 @@ class Matching:
         if isinstance(dem_path, Path):
             dem_path = str(dem_path)
         m = Matching()
-        m._matching_graph = _cpp_pm.detector_error_model_file_to_matching_graph(dem_path)
+        m._matching_graph = _cpp_pm.detector_error_model_file_to_matching_graph(dem_path, enable_correlations=enable_correlations)
         return m
 
     @staticmethod

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -301,7 +301,7 @@ void iter_dem_instructions_include_correlations(
                 } else {
                     // Undecomposed hyperedges are not supported
                     throw std::invalid_argument(
-                        "Encountered an undecomposed error instruction with 3 or mode detectors. "
+                        "Encountered an undecomposed error instruction with 3 or more detectors. "
                         "This is not supported when using `enable_correlations=True`. "
                         "Did you forget to set `decompose_errors=True` when "
                         "converting the stim circuit to a detector error model?");
@@ -328,7 +328,7 @@ void iter_dem_instructions_include_correlations(
         if (component->node1 == SIZE_MAX) {
             // Undecomposed hyperedges are not supported
             throw std::invalid_argument(
-                "Encountered an undecomposed error instruction with 3 or mode detectors. "
+                "Encountered an undecomposed error instruction with 3 or more detectors. "
                 "This is not supported when using `enable_correlations=True`. "
                 "Did you forget to set `decompose_errors=True` when "
                 "converting the stim circuit to a detector error model?");

--- a/src/pymatching/sparse_blossom/driver/user_graph.h
+++ b/src/pymatching/sparse_blossom/driver/user_graph.h
@@ -309,31 +309,22 @@ void iter_dem_instructions_include_correlations(
             } else if (target.is_observable_id()) {
                 component->observable_indices.push_back(target.val());
             } else if (target.is_separator()) {
-                // If the previous error in the decomposition had 3 or more components, we ignore it.
-                if (component->node1 == SIZE_MAX) {
-                    throw std::invalid_argument(
-                        "Encountered a decomposed error instruction with a hyperedge component (3 or more detectors). "
-                        "This is not supported.");
-                } else if (p > 0) {
-                    handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+                if (p > 0 && num_component_detectors > 0) {
+                    if (num_component_detectors == 1) {
+                        handle_dem_error(p, {component->node1}, component->observable_indices);
+                    } else {
+                        handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);
+                    }
                 }
-                decomposed_err.components.push_back({});
-                component = &decomposed_err.components.back();
-                component->node1 = SIZE_MAX;
-                component->node2 = SIZE_MAX;
-                num_component_detectors = 0;
             }
+            decomposed_err.components.push_back({});
+            component = &decomposed_err.components.back();
+            component->node1 = SIZE_MAX;
+            component->node2 = SIZE_MAX;
+            num_component_detectors = 0;
         }
-        // If the final error in the decomposition had 3 or more components, we ignore it.
-        if (component->node1 == SIZE_MAX) {
-            // Undecomposed hyperedges are not supported
-            throw std::invalid_argument(
-                "Encountered an undecomposed error instruction with 3 or more detectors. "
-                "This is not supported when using `enable_correlations=True`. "
-                "Did you forget to set `decompose_errors=True` when "
-                "converting the stim circuit to a detector error model?");
-        } else if (p > 0) {
-            if (component->node2 == SIZE_MAX) {
+        if (p > 0 && num_component_detectors > 0) {
+            if (num_component_detectors == 1) {
                 handle_dem_error(p, {component->node1}, component->observable_indices);
             } else {
                 handle_dem_error(p, {component->node1, component->node2}, component->observable_indices);


### PR DESCRIPTION
Firstly, thanks @smadhuk and @oscarhiggott for implementing correlated matching!

When integrating correlated `pymatching` into `sinter`, I encountered some failing tests. For example, the following code:

```python
import stim
import pymatching

dem = stim.DetectorErrorModel("""
repeat 14 {
    error(0.1) D0
    shift_detectors 1
}
error(0.1) D0
error(0.1) L0
""")

matching = pymatching.Matching.from_detector_error_model(dem, enable_correlations=True)
```

raises:

```bash
ValueError: Encountered an undecomposed error instruction with 3 or more detectors. This is not supported when using `enable_correlations=True`. Did you forget to set `decompose_errors=True` when converting the stim circuit to a detector error model?
```

The root cause is here:
[https://github.com/oscarhiggott/PyMatching/blob/71115305a94ae4f276f20cf43f4c2486d74d0729/src/pymatching/sparse\_blossom/driver/user\_graph.h#L328-L334](https://github.com/oscarhiggott/PyMatching/blob/71115305a94ae4f276f20cf43f4c2486d74d0729/src/pymatching/sparse_blossom/driver/user_graph.h#L328-L334)

Specifically, the `dem` instruction `error(0.1) L0` has no detectors, so `component->node1 == SIZE_MAX` is true. The expected behavior would be to silently ignore such instructions rather than raising an exception. This issue appears to stem from mismatched error conditions between commits da0bba6 and 59bd90f.

This PR addresses the above issue, fixes some typos, and adds the `enable_correlations` argument to `Matching.from_detector_error_model_file`.
