### PR TITLE
Include license information in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ setup(
     description="A package for decoding quantum error correcting codes using minimum-weight perfect matching.",
     long_description=long_description,
     long_description_content_type='text/markdown',
+    license="Apache 2",
     ext_modules=[CMakeExtension("pymatching._cpp_pymatching")],
     packages=find_packages("src"),
     package_dir={'': 'src'},


### PR DESCRIPTION
This should cause the license metadata to be populated in pypi to be available for other tools.